### PR TITLE
Feature/3 멤버 & 인증 테스트 구현 및 인증 에러 핸들링 수정

### DIFF
--- a/src/main/java/com/pnu/momeet/common/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/pnu/momeet/common/advice/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.pnu.momeet.common.advice;
 
+import com.pnu.momeet.common.exception.BannedAccountException;
+import com.pnu.momeet.common.exception.ExistEmailException;
 import com.pnu.momeet.common.exception.UnMatchedPasswordException;
 import org.apache.tomcat.websocket.AuthenticationException;
 import org.springframework.http.HttpStatus;
@@ -71,12 +73,17 @@ public class GlobalExceptionHandler {
         return ResponseEntity.badRequest().body(problemDetail);
     }
 
-    @ExceptionHandler(AuthenticationException.class)
-    public ResponseEntity<ProblemDetail> handleAuthenticationException(AuthenticationException e) {
-        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, e.getMessage());
-        problemDetail.setTitle("인증 실패 오류");
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(problemDetail);
+    @ExceptionHandler(BannedAccountException.class)
+    public ResponseEntity<ProblemDetail> handleBannedAccountException(BannedAccountException e) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.FORBIDDEN, e.getMessage());
+        problemDetail.setTitle("차단된 계정 오류");
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(problemDetail);
     }
 
-
+    @ExceptionHandler(ExistEmailException.class)
+    public ResponseEntity<ProblemDetail> handleExistEmailException(ExistEmailException e) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, e.getMessage());
+        problemDetail.setTitle("중복된 이메일 오류");
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(problemDetail);
+    }
 }

--- a/src/main/java/com/pnu/momeet/common/exception/ExistEmailException.java
+++ b/src/main/java/com/pnu/momeet/common/exception/ExistEmailException.java
@@ -1,0 +1,7 @@
+package com.pnu.momeet.common.exception;
+
+public class ExistEmailException extends RuntimeException {
+    public ExistEmailException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/pnu/momeet/common/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/pnu/momeet/common/security/handler/CustomAuthenticationEntryPoint.java
@@ -1,5 +1,8 @@
 package com.pnu.momeet.common.security.handler;
 
+import com.pnu.momeet.common.exception.BannedAccountException;
+import com.pnu.momeet.common.exception.ConcurrentLoginException;
+import com.pnu.momeet.common.exception.DisabledAccountException;
 import com.pnu.momeet.common.mapper.ProblemDetailMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -25,16 +28,47 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
             AuthenticationException authException
     ) throws IOException {
 
-        response.setStatus(HttpStatus.UNAUTHORIZED.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
 
-        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
-                HttpStatus.UNAUTHORIZED,
-                authException.getMessage()
-        );
-        problemDetail.setTitle("인증 실패 오류");
-        problemDetail.setInstance(URI.create(request.getRequestURI()));
+        ProblemDetail problemDetail;
+
+        switch (authException) {
+            case BannedAccountException ignored -> {
+                response.setStatus(HttpStatus.FORBIDDEN.value());
+                problemDetail = ProblemDetail.forStatusAndDetail(
+                        HttpStatus.FORBIDDEN,
+                        authException.getMessage()
+                );
+                problemDetail.setTitle("차단된 계정 오류");
+            }
+            case ConcurrentLoginException ignored -> {
+                response.setStatus(HttpStatus.UNAUTHORIZED.value());
+                problemDetail = ProblemDetail.forStatusAndDetail(
+                        HttpStatus.UNAUTHORIZED,
+                        authException.getMessage()
+                );
+                problemDetail.setTitle("중복 로그인 오류");
+            }
+            case DisabledAccountException ignored -> {
+                response.setStatus(HttpStatus.UNAUTHORIZED.value());
+                problemDetail = ProblemDetail.forStatusAndDetail(
+                        HttpStatus.UNAUTHORIZED,
+                        authException.getMessage()
+                );
+                // 사용자 계정 정보 변경 등에 의해 인증은 되었으나, 계정이 비활성화된 경우
+                problemDetail.setTitle("비활성화된 계정 오류");
+            }
+            default -> {
+                response.setStatus(HttpStatus.UNAUTHORIZED.value());
+                problemDetail = ProblemDetail.forStatusAndDetail(
+                        HttpStatus.UNAUTHORIZED,
+                        authException.getMessage()
+                );
+                problemDetail.setTitle("인증 실패 오류");
+                problemDetail.setInstance(URI.create(request.getRequestURI()));
+            }
+        }
 
         response.getWriter().write(problemDetailMapper.toJson(problemDetail));
     }

--- a/src/main/java/com/pnu/momeet/domain/member/service/MemberService.java
+++ b/src/main/java/com/pnu/momeet/domain/member/service/MemberService.java
@@ -48,6 +48,10 @@ public class MemberService {
         );
     }
 
+    public boolean existsByEmail(String email) {
+        return memberRepository.existsByEmail(email);
+    }
+
     public Member disableMemberById(UUID id) {
         Member member = findMemberById(id);
         member.setEnabled(false);

--- a/src/main/java/com/pnu/momeet/domain/member/service/MemberService.java
+++ b/src/main/java/com/pnu/momeet/domain/member/service/MemberService.java
@@ -64,7 +64,8 @@ public class MemberService {
 
     @Transactional
     public Member validateAndUpdatePasswordById(UUID id, String oldPassword, String newPassword) {
-        Member member = disableMemberById(id); // 사용자 정보 변경 전 비활성화
+        Member member = findMemberById(id);
+        member.setEnabled(false); // 비밀번호 변경 전 비활성화
 
         if (!passwordEncoder.matches(oldPassword, member.getPassword())) {
             throw new IllegalArgumentException("기존 비밀번호가 일치하지 않습니다.");
@@ -75,7 +76,8 @@ public class MemberService {
 
     @Transactional
     public Member updatePasswordById(UUID id, String newPassword) {
-        Member member = disableMemberById(id);
+        Member member = findMemberById(id);
+        member.setEnabled(false); // 비밀번호 변경 전 비활성화
         member.setPassword(passwordEncoder.encode(newPassword));
         return memberRepository.save(member);
     }

--- a/src/test/java/com/pnu/momeet/e2e/auth/AuthLoginTest.java
+++ b/src/test/java/com/pnu/momeet/e2e/auth/AuthLoginTest.java
@@ -1,0 +1,98 @@
+package com.pnu.momeet.e2e.auth;
+
+import com.pnu.momeet.domain.auth.dto.LoginRequest;
+import com.pnu.momeet.domain.auth.dto.TokenResponse;
+import com.pnu.momeet.domain.member.entity.Member;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.*;
+
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+@DisplayName("인증 E2E 테스트 - 로그인")
+public class AuthLoginTest extends BaseAuthTest {
+
+    @Test
+    @DisplayName("로그인 성공 테스트")
+    public void login_success() {
+        LoginRequest request = new LoginRequest(testMember.getEmail(), testPassword);
+        TokenResponse response = RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .post("/login")
+                .then()
+                .log().all()
+                .statusCode(200)
+                .body(
+                        "accessToken", notNullValue(),
+                        "refreshToken", notNullValue()
+                )
+                .extract()
+                .as(TokenResponse.class);
+
+        testTokenPair(response, testMember);
+
+        Member loggedInMember = memberService.findMemberById(testMember.getId());
+        assertThat(loggedInMember.isEnabled()).isTrue(); // 계정 활성화 여부
+        assertThat(loggedInMember.getTokenIssuedAt()).isNotNull(); // 토큰 발급 시점
+    }
+
+    @Test
+    @DisplayName("로그인 실패 테스트 - 잘못된 요청(400 Bad Request)")
+    public void login_fail_invalid_request() {
+        List.of(
+            new LoginRequest("invalidEmail", "testAuth123!"), // 잘못된 이메일
+            new LoginRequest("test@test.com", "short") // 짧은 비밀번호
+        ).forEach(request ->
+            RestAssured
+                .given()
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                .when()
+                    .post("/login")
+                .then()
+                    .log().all()
+                    .statusCode(400));
+    }
+
+    @Test
+    @DisplayName("로그인 실패 테스트 - 잘못된 이메일 혹은 비밀번호(401 Unauthorized)")
+    public void login_fail_invalid_email_or_password() {
+        List.of(
+                new LoginRequest("notExist@test.com", "testAuth123!"),
+                new LoginRequest(testMember.getEmail(), "testAuth1!")
+        ).forEach(request ->
+            RestAssured
+                .given()
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                .when()
+                    .post("/login")
+                .then()
+                    .log().all()
+                    .statusCode(401)
+        );
+    }
+
+    @Test
+    @DisplayName("로그인 실패 테스트 - 계정 잠금(403 Forbidden)")
+    public void login_fail_banned_account() {
+        // given
+        memberService.updateMemberById(testMember.getId(), member -> member.setAccountNonLocked(false));
+
+        LoginRequest request = new LoginRequest(testMember.getEmail(), testPassword);
+        RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .post("/login")
+                .then()
+                .log().all()
+                .statusCode(403);
+    }
+}

--- a/src/test/java/com/pnu/momeet/e2e/auth/AuthRefreshTest.java
+++ b/src/test/java/com/pnu/momeet/e2e/auth/AuthRefreshTest.java
@@ -1,0 +1,102 @@
+package com.pnu.momeet.e2e.auth;
+
+import com.pnu.momeet.common.model.TokenPair;
+import com.pnu.momeet.domain.auth.dto.RefreshRequest;
+import com.pnu.momeet.domain.auth.dto.TokenResponse;
+import com.pnu.momeet.domain.auth.entity.RefreshToken;
+import com.pnu.momeet.domain.auth.repository.RefreshTokenRepository;
+import com.pnu.momeet.domain.auth.service.EmailAuthService;
+import com.pnu.momeet.domain.member.entity.Member;
+import com.pnu.momeet.domain.member.enums.Role;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+@DisplayName("인증 E2E 테스트 - 토큰 재발급")
+public class AuthRefreshTest extends BaseAuthTest {
+
+    @Autowired
+    private EmailAuthService emailAuthService;
+    private Member loggedInMember;
+    private TokenPair loginnedInTokenPair;
+
+    @Autowired
+    RefreshTokenRepository refreshTokenRepository;
+
+    @BeforeEach
+    @Override
+    protected void setup() {
+        super.setup();
+        loggedInMember = new Member("testRefrsh@test.com", testPassword, List.of(Role.ROLE_USER));
+        loggedInMember = memberService.saveMember(loggedInMember);
+        loginnedInTokenPair = emailAuthService.login(loggedInMember.getEmail(), testPassword);
+
+        toBeDeleted.add(loggedInMember);
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 성공 테스트")
+    public void refresh_success() {
+        RefreshRequest request = new RefreshRequest(loginnedInTokenPair.refreshToken());
+        TokenResponse pair = RestAssured
+            .given()
+                .contentType("application/json")
+                .body(request)
+            .when()
+                .post("/refresh")
+            .then()
+                .log().all()
+                .statusCode(200)
+                .extract()
+                .as(TokenResponse.class);
+
+        testTokenPair(pair, loggedInMember);
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 실패 - 유효하지 않은 리프레시 토큰 (400 Bad Request)")
+    public void refresh_fail_invalid_request() {
+        List.of(
+            new RefreshRequest("short"), // 너무 짧은 토큰
+            new RefreshRequest("this.is.not.a.valid.token") // 형식에 맞지 않는 토큰
+        ).forEach(request ->
+            RestAssured
+                .given()
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                .when()
+                    .post("/refresh")
+                .then()
+                    .log().all()
+                    .statusCode(400)
+        );
+    }
+    
+    @Test
+    @DisplayName("토큰 재발급 실패 - 만료된 리프레시 토큰 (401 Unauthorized)")
+    public void refresh_fail_expired_token() {
+        // 리프레시 토큰을 강제로 만료시킴
+        RefreshToken refreshToken = new RefreshToken(
+            loggedInMember.getId(),
+            jwtTokenProvider.generateToken(loggedInMember.getId().toString(), -1000L) // 이미 만료된 토큰 생성
+        );
+        refreshTokenRepository.save(refreshToken); // DB에 저장
+
+        RefreshRequest request = new RefreshRequest(refreshToken.getValue());
+        RestAssured
+            .given()
+                .contentType(ContentType.JSON)
+                .body(request)
+            .when()
+                .post("/refresh")
+            .then()
+                .log().all()
+                .statusCode(401);
+    }
+}
+

--- a/src/test/java/com/pnu/momeet/e2e/auth/AuthSignupTest.java
+++ b/src/test/java/com/pnu/momeet/e2e/auth/AuthSignupTest.java
@@ -1,0 +1,89 @@
+package com.pnu.momeet.e2e.auth;
+
+import com.pnu.momeet.domain.auth.dto.SignupRequest;
+import com.pnu.momeet.domain.auth.dto.TokenResponse;
+import com.pnu.momeet.domain.member.entity.Member;
+import com.pnu.momeet.domain.member.enums.Provider;
+import com.pnu.momeet.domain.member.enums.Role;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+
+@DisplayName("인증 E2E 테스트 - 회원가입")
+public class AuthSignupTest extends BaseAuthTest {
+
+    @Test
+    @DisplayName("회원가입 성공 테스트")
+    public void signup_success() {
+        SignupRequest request = new SignupRequest("testSignup@test.com", "testSignup123@", "testSignup123@");
+        TokenResponse response = RestAssured
+            .given()
+                .contentType(ContentType.JSON)
+                .body(request)
+            .when()
+                .post("/signup")
+            .then()
+                .log().all()
+                .statusCode(200)
+                .body(
+                        "accessToken", notNullValue(),
+                        "refreshToken", notNullValue()
+                )
+                .extract()
+                .as(TokenResponse.class);
+
+        Member signedUpMember = memberService.findMemberByEmail(request.email());
+        toBeDeleted.add(signedUpMember); // 회원가입한 계정 삭제를 위해 리스트에 추가
+
+        testTokenPair(response, signedUpMember);
+        assertThat(signedUpMember).isNotNull();
+        assertThat(signedUpMember.getProvider()).isEqualTo(Provider.EMAIL);
+        assertThat(signedUpMember.isEnabled()).isTrue(); // 계정 활성화 여부
+        assertThat(signedUpMember.getTokenIssuedAt()).isNotNull(); // 토큰 발급 시점
+        assertThat(signedUpMember.getRoles().size()).isEqualTo(1);
+        assertThat(signedUpMember.getRoles().getFirst().getName()).isEqualTo(Role.ROLE_USER);
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 테스트 - 잘못된 요청(400 Bad Request)")
+    public void signup_fail_invalid_request() {
+        List.of(
+            Map.of("email", "invalidEmail", "password1", "testSignup123@", "password2", "testSignup123@"), // 잘못된 이메일
+            Map.of("email", "valid@test.com", "password1", "short", "password2", "short"), // 짧은 비밀번호
+            Map.of("email", "valid@test.com", "password1", "testSignup123@", "password2", "different123@") // 비밀번호 불일치
+        ).forEach(body ->
+            RestAssured
+            .given()
+                .contentType(ContentType.JSON)
+                .body(body)
+            .when()
+                .post("/signup")
+            .then()
+                .log().all()
+                .statusCode(400)
+                .body("validationErrors", notNullValue())
+        );
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 테스트 - 중복된 이메일(409 Conflict)")
+    public void signup_fail_duplicate_email() {
+        SignupRequest request = new SignupRequest(testMember.getEmail(), "testSignup123@", "testSignup123@");
+        RestAssured
+            .given()
+                .contentType(ContentType.JSON)
+                .body(request)
+            .when()
+                .post("/signup")
+            .then()
+                .log().all()
+                .statusCode(409);
+    }
+}

--- a/src/test/java/com/pnu/momeet/e2e/auth/BaseAuthTest.java
+++ b/src/test/java/com/pnu/momeet/e2e/auth/BaseAuthTest.java
@@ -1,9 +1,63 @@
 package com.pnu.momeet.e2e.auth;
 
+import com.pnu.momeet.common.model.TokenInfo;
+import com.pnu.momeet.common.security.JwtTokenProvider;
+import com.pnu.momeet.domain.auth.dto.TokenResponse;
+import com.pnu.momeet.domain.member.entity.Member;
+import com.pnu.momeet.domain.member.enums.Role;
+import com.pnu.momeet.domain.member.service.MemberService;
 import com.pnu.momeet.e2e.BaseE2ETest;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @Tag("auth")
 public abstract class BaseAuthTest extends BaseE2ETest {
 
+    @Autowired
+    protected MemberService memberService;
+
+    @Autowired
+    protected JwtTokenProvider jwtTokenProvider;
+
+    protected Member testMember;
+    protected List<Member> toBeDeleted;
+
+    protected String testPassword = "testAuth123@";
+
+    @BeforeEach
+    protected void setup() {
+        super.setup();
+        RestAssured.basePath = "/api/auth";
+        toBeDeleted = new ArrayList<>();
+        testMember = new Member("testAuth@test.com", testPassword, List.of(Role.ROLE_USER));
+        testMember = memberService.saveMember(testMember);
+        toBeDeleted.add(testMember);
+    }
+
+    @AfterEach
+    protected void tearDown() {
+        if (toBeDeleted != null && !toBeDeleted.isEmpty()) {
+            toBeDeleted.forEach(member -> memberService.deleteMemberById(member.getId()));
+            toBeDeleted.clear();
+        }
+    }
+
+    protected void testTokenPair(TokenResponse response, Member member) {
+        TokenInfo accessTokenInfo = jwtTokenProvider.parseToken(response.accessToken());
+        assertThat(accessTokenInfo.subject()).isEqualTo(member.getId().toString());
+        assertThat(accessTokenInfo.expiresAt()).isAfter(LocalDateTime.now());
+
+        TokenInfo refreshTokenInfo = jwtTokenProvider.parseToken(response.refreshToken());
+        assertThat(refreshTokenInfo.subject()).isEqualTo(member.getId().toString());
+        assertThat(refreshTokenInfo.expiresAt()).isAfter(LocalDateTime.now());
+    }
 }

--- a/src/test/java/com/pnu/momeet/unit/BaseUnitTest.java
+++ b/src/test/java/com/pnu/momeet/unit/BaseUnitTest.java
@@ -1,0 +1,11 @@
+package com.pnu.momeet.unit;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@Tag("unit")
+@ExtendWith(MockitoExtension.class)
+public abstract class BaseUnitTest {
+
+}

--- a/src/test/java/com/pnu/momeet/unit/GeneratorTest.java
+++ b/src/test/java/com/pnu/momeet/unit/GeneratorTest.java
@@ -1,14 +1,20 @@
 package com.pnu.momeet.unit;
 
+import com.pnu.momeet.common.security.JwtTokenProvider;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.UUID;
+
 @SpringBootTest
 public class GeneratorTest {
     @Autowired
     private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
 
     @Test
     public void testPasswordEncoding() {
@@ -20,7 +26,19 @@ public class GeneratorTest {
     @Test
     public void testUUIDGeneration() {
         for (int i = 0; i < 5; i++) {
-            System.out.println("Generated UUID: " + java.util.UUID.randomUUID());
+            System.out.println("Generated UUID: " + UUID.randomUUID());
         }
+    }
+
+    @Test
+    public void testJwtTokenGeneration() {
+        UUID userId = UUID.randomUUID();
+        System.out.println("User ID: " + userId);
+
+        String accessToken = jwtTokenProvider.generateAccessToken(userId);
+        System.out.println("Access Token: " + accessToken);
+
+        String refreshToken = jwtTokenProvider.generateRefreshToken(userId);
+        System.out.println("Refresh Token: " + refreshToken);
     }
 }

--- a/src/test/java/com/pnu/momeet/unit/auth/AuthServiceTest.java
+++ b/src/test/java/com/pnu/momeet/unit/auth/AuthServiceTest.java
@@ -1,0 +1,138 @@
+package com.pnu.momeet.unit.auth;
+
+
+import com.pnu.momeet.common.model.TokenPair;
+import com.pnu.momeet.common.security.JwtTokenProvider;
+import com.pnu.momeet.domain.auth.entity.RefreshToken;
+import com.pnu.momeet.domain.auth.repository.RefreshTokenRepository;
+import com.pnu.momeet.domain.auth.service.EmailAuthService;
+import com.pnu.momeet.domain.member.entity.Member;
+import com.pnu.momeet.domain.member.enums.Provider;
+import com.pnu.momeet.domain.member.enums.Role;
+import com.pnu.momeet.domain.member.service.MemberService;
+import com.pnu.momeet.unit.BaseUnitTest;
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Tag("auth")
+@Tag("service")
+public class AuthServiceTest extends BaseUnitTest {
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private JwtTokenProvider tokenProvider;
+
+    @Mock
+    private MemberService memberService;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private EmailAuthService authService;
+
+    @Test
+    @DisplayName("회원가입(signUp) 테스트")
+    public void testSignUp() {
+        // given
+        String email = "test@email.com";
+        String password = "pw123";
+        Member member = new Member(email, password, List.of(Role.ROLE_USER));
+        member.setId(UUID.randomUUID());
+
+        // when
+        Mockito.when(memberService.saveMember(Mockito.any(Member.class))).thenReturn(member);
+        Mockito.when(tokenProvider.generateAccessToken(member.getId())).thenReturn("access");
+        Mockito.when(tokenProvider.generateRefreshToken(member.getId())).thenReturn("refresh");
+        Mockito.when(refreshTokenRepository.save(Mockito.any())).thenReturn(null);
+        Mockito.when(memberService.updateMemberById(Mockito.any(), Mockito.any())).thenReturn(member);
+
+        // then
+        TokenPair result = authService.signUp(email, password);
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals("refresh", result.refreshToken());
+        Assertions.assertEquals("access", result.accessToken());
+    }
+
+    @Test
+    @DisplayName("로그인(login) 테스트")
+    public void testLogin() {
+        // given
+        String email = "test@email.com";
+        String password = "pw123";
+        Member member = new Member(email, password, List.of(Role.ROLE_USER));
+        member.setId(UUID.randomUUID());
+        member.setProvider(Provider.EMAIL);
+        member.setAccountNonLocked(true);
+
+        // when
+        Mockito.when(memberService.findMemberByEmail(email))
+                .thenReturn(member);
+        Mockito.when(passwordEncoder.matches(password, member.getPassword()))
+                .thenReturn(true);
+        Mockito.when(tokenProvider.generateAccessToken(member.getId())).thenReturn("access");
+        Mockito.when(tokenProvider.generateRefreshToken(member.getId())).thenReturn("refresh");
+
+        // then
+        TokenPair result = authService.login(email, password);
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals("refresh", result.refreshToken());
+        Assertions.assertEquals("access", result.accessToken());
+    }
+
+    @Test
+    @DisplayName("로그아웃(logout) 테스트")
+    public void testLogout() {
+        // given
+        UUID memberId = UUID.randomUUID();
+        // when
+        Mockito.when(refreshTokenRepository.existsById(memberId)).thenReturn(true);
+
+        authService.logout(memberId);
+
+        // then
+        Mockito.verify(memberService).disableMemberById(memberId);
+        Mockito.verify(refreshTokenRepository).deleteById(memberId);
+    }
+
+    @Test
+    @DisplayName("토큰 리프레시(refreshTokens) 테스트")
+    public void testRefreshTokens() {
+        // given
+        String refreshToken = "refreshTokenValue";
+        UUID memberId = UUID.randomUUID();
+        RefreshToken savedToken = new RefreshToken(memberId, refreshToken);
+        Claims claims = Mockito.mock(Claims.class);
+
+        // when
+        Mockito.when(tokenProvider.getPayload(refreshToken)).thenReturn(claims);
+        Mockito.when(claims.getSubject()).thenReturn(memberId.toString());
+        Mockito.when(refreshTokenRepository.findById(memberId)).thenReturn(Optional.of(savedToken));
+        Mockito.when(tokenProvider.generateAccessToken(memberId)).thenReturn("access");
+        Mockito.when(tokenProvider.generateRefreshToken(memberId)).thenReturn("refresh");
+        Mockito.when(refreshTokenRepository.save(Mockito.any())).thenReturn(null);
+        // Member 생성자 접근 오류 해결: 테스트용 임의 Member 객체 생성
+        Member dummyMember = new Member("dummy@email.com", "dummyPw", List.of(Role.ROLE_USER));
+        dummyMember.setId(memberId);
+        Mockito.when(memberService.updateMemberById(Mockito.any(), Mockito.any())).thenReturn(dummyMember);
+
+        // then
+        TokenPair result = authService.refreshTokens(refreshToken);
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals("refresh", result.refreshToken());
+        Assertions.assertEquals("access", result.accessToken());
+    }
+}

--- a/src/test/java/com/pnu/momeet/unit/member/MemberServiceTest.java
+++ b/src/test/java/com/pnu/momeet/unit/member/MemberServiceTest.java
@@ -1,0 +1,123 @@
+package com.pnu.momeet.unit.member;
+
+import com.pnu.momeet.domain.member.entity.Member;
+import com.pnu.momeet.domain.member.enums.Role;
+import com.pnu.momeet.domain.member.repository.MemberRepository;
+import com.pnu.momeet.domain.member.service.MemberService;
+import com.pnu.momeet.unit.BaseUnitTest;
+import org.junit.jupiter.api.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.List;
+import java.util.UUID;
+
+@Tag("member")
+@Tag("service")
+public class MemberServiceTest extends BaseUnitTest {
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Test
+    @DisplayName("멤버 저장 테스트")
+    public void testSaveMember() {
+        // given
+        Member newMember = new Member("test@test.com", "password123", List.of(Role.ROLE_USER));
+
+        // when
+        Mockito.when(passwordEncoder.encode(Mockito.anyString()))
+                .thenAnswer(invocation -> "encoded_" + invocation.getArgument(0));
+        Mockito.when(memberRepository.existsByEmail(newMember.getEmail()))
+            .thenReturn(false);
+        Mockito.when(memberRepository.save(Mockito.any(Member.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        Member savedMember = memberService.saveMember(newMember);
+        // then
+        Assertions.assertNotNull(savedMember);
+        Assertions.assertEquals("encoded_password123", savedMember.getPassword());
+        Mockito.verify(memberRepository).save(newMember);
+    }
+
+    @Test
+    @DisplayName("멤버 정보 수정 테스트")
+    public void testUpdateMemberById() {
+        // given
+        Member originMember = new Member("test@test.com", "password123", List.of(Role.ROLE_USER));
+        originMember.setId(UUID.randomUUID());
+        UUID memberId = originMember.getId();
+        originMember.setEnabled(true);
+
+
+        Mockito.when(memberRepository.findById(memberId))
+                .thenReturn(java.util.Optional.of(originMember));
+        Mockito.when(memberRepository.save(Mockito.any(Member.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when: 닉네임 변경
+        Member updated = memberService.updateMemberById(memberId, m -> m.setAccountNonLocked(false));
+
+        // then
+        Assertions.assertFalse(updated.isEnabled()); // 수정 전 비활성화
+        Assertions.assertFalse(updated.isAccountNonLocked()); // 수정된 값
+        Mockito.verify(memberRepository).save(originMember);
+    }
+
+    @Test
+    @DisplayName("일반 사용자 비밀번호 변경 테스트 (기존 비밀번호 검증)")
+    public void testValidateAndUpdatePasswordById() {
+        // given
+        UUID memberId = UUID.randomUUID();
+        Member member = new Member("user@test.com", "encoded_oldpass", List.of(Role.ROLE_USER));
+        member.setId(memberId);
+        member.setEnabled(true);
+
+        Mockito.when(memberRepository.findById(memberId))
+                .thenReturn(java.util.Optional.of(member));
+        Mockito.when(memberRepository.save(Mockito.any(Member.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        Mockito.when(passwordEncoder.matches("oldpass", "encoded_oldpass")).thenReturn(true);
+        Mockito.when(passwordEncoder.encode("newpass")).thenReturn("encoded_newpass");
+
+        // when
+        Member updated = memberService.validateAndUpdatePasswordById(memberId, "oldpass", "newpass");
+
+        // then
+        Assertions.assertFalse(updated.isEnabled()); // 변경 전 비활성화
+        Assertions.assertEquals("encoded_newpass", updated.getPassword());
+        Mockito.verify(memberRepository).save(member);
+    }
+
+    @Test
+    @DisplayName("관리자 비밀번호 변경 테스트 (기존 비밀번호 검증 없이)")
+    public void testUpdatePasswordById() {
+        // given
+        UUID memberId = UUID.randomUUID();
+        Member member = new Member("admin@test.com", "encoded_adminpass", List.of(Role.ROLE_ADMIN));
+        member.setId(memberId);
+        member.setEnabled(true);
+
+        Mockito.when(memberRepository.findById(memberId))
+                .thenReturn(java.util.Optional.of(member));
+        Mockito.when(memberRepository.save(Mockito.any(Member.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        Mockito.when(passwordEncoder.encode("newadminpass")).thenReturn("encoded_newadminpass");
+
+        // when
+        Member updated = memberService.updatePasswordById(memberId, "newadminpass");
+
+        // then
+        Assertions.assertFalse(updated.isEnabled()); // 변경 전 비활성화
+        Assertions.assertEquals("encoded_newadminpass", updated.getPassword());
+        Mockito.verify(memberRepository).save(member);
+    }
+}


### PR DESCRIPTION
# Pull Request 템플릿

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 걸어주세요 -->
- #3 #4 

## 💡 변경 이유
<!-- 왜 이 코드 변경이 필요했나요? 어떤 문제를 해결하거나 어떤 기능을 추가했나요? -->
- member,auth 관련 에러 핸들링를 일부 수정했습니다
- Authentication에 에러처리는 AuthenticationEntryPoint에서 담당합니다. 제가 filter가 역방향으로도 적용된다는 점을 간과하고 GlobalHandler에도 이를 핸들링 해줬는데 이 사항을 제외했습니다.
- memberService에서  내부적으로 disableMemberById 함수를 내부에서도 처리하도록 사용했는데 save 연산을 쓸데 없이 2번 사용하는것을 확인했습니다.  이를 findBy와 setter로 변경했습니다.

## 📋 주요 변경사항
<!-- 구체적으로 어떤 것들이 변경되었는지 간단히 나열해주세요 -->
- BaseUnitTest 구현(mockio 익스텐션 추가)
- memberServiceTest 구현
- authServiceTest 구현
- authE2e 테스트 구현
    - 로그인 e2e 테스트 구현
    - 회원가입 e2e 테스트 구현
    - 토큰 재발급 e2e 테스트 구현
    - 로그아웃 e2e 테스트 구현

## ⚠️ 발견된 위험이나 장애
<!-- 개발 중 발견된 문제점이나 주의할 부분이 있다면 작성해주세요 (없으면  삭제) -->


## 👀 리뷰 포인트
<!-- 리뷰어가 특별히 집중해서 봐야 할 부분을 알려주세요 -->
- 에러 핸들링 절차를 수정하고 특정 에러에 어떤 에러코드를 반환하는지에 대해 고도화 했으니 memberService, EmailAuthService, GlobalExpetionHandler 단을 자세히 봐주시기 바랍니다
- 

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 (없으면 삭제해도 됩니다) -->


## ✅ 테스트 완료 사항
<!-- 어떻게 테스트했는지 간단히 작성해주세요 -->
- [X] 로컬에서 정상 동작 확인
- [X] 유닛 테스트
- [X] e2e 테스트 
