### PR TITLE
FIX/32 파일 크기 검증 로직 오류 수정

### DIFF
--- a/src/main/java/com/pnu/momeet/common/config/MultipartProperties.java
+++ b/src/main/java/com/pnu/momeet/common/config/MultipartProperties.java
@@ -1,0 +1,16 @@
+package com.pnu.momeet.common.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.util.unit.DataSize;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "spring.servlet.multipart")
+public class MultipartProperties {
+    private DataSize maxFileSize;
+    private DataSize maxRequestSize;
+}

--- a/src/main/java/com/pnu/momeet/common/validation/validator/ImageValidator.java
+++ b/src/main/java/com/pnu/momeet/common/validation/validator/ImageValidator.java
@@ -1,5 +1,6 @@
 package com.pnu.momeet.common.validation.validator;
 
+import com.pnu.momeet.common.config.MultipartProperties;
 import com.pnu.momeet.common.validation.annotation.ValidImage;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
@@ -8,13 +9,13 @@ import java.io.InputStream;
 import java.util.Locale;
 import java.util.Set;
 import javax.imageio.ImageIO;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 
+@RequiredArgsConstructor
 public class ImageValidator implements ConstraintValidator<ValidImage, MultipartFile> {
 
-    @Value("${spring.servlet.multipart.max-file-size}")
-    private static long MAX_FILE_SIZE;
+    private final MultipartProperties multipartProperties;
     private static final Set<String> ALLOWED_EXT = Set.of("jpg", "jpeg", "png", "gif", "webp");
 
     @Override
@@ -24,7 +25,7 @@ public class ImageValidator implements ConstraintValidator<ValidImage, Multipart
         }
 
         // 1. 파일 크기 검증
-        if (file.getSize() > MAX_FILE_SIZE) {
+        if (file.getSize() > multipartProperties.getMaxFileSize().toBytes()) {
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate("파일 크기는 5MB를 초과할 수 없습니다.")
                 .addConstraintViolation();


### PR DESCRIPTION
# Pull Request 템플릿

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 걸어주세요 -->
- Closes #(32)

## 💡 변경 이유
<!-- 왜 이 코드 변경이 필요했나요? 어떤 문제를 해결하거나 어떤 기능을 추가했나요? -->

파일 크기 검증 로직에서 파일 크기 필드 MAX_FILE_SIZE 값이 null 로 설정되는 오류가 있었습니다.

## 📋 주요 변경사항
<!-- 구체적으로 어떤 것들이 변경되었는지 간단히 나열해주세요 -->
- ImageValidator에서 @Value static 필드 사용 제거
- MultipartProperties(@ConfigurationProperties) Bean을 주입받도록 수정
- 파일 크기 제한을 application.yml 값(max-file-size)과 동기화


## 👀 리뷰 포인트
<!-- 리뷰어가 특별히 집중해서 봐야 할 부분을 알려주세요 -->
- 
- 

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 (없으면 삭제해도 됩니다) -->


## ✅ 테스트 완료 사항
<!-- 어떻게 테스트했는지 간단히 작성해주세요 -->
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인