### PR TITLE
fix: Spring Cloud AWS 설정 prefix 수정 (#35)

### DIFF
--- a/src/main/java/com/pnu/momeet/common/config/S3Config.java
+++ b/src/main/java/com/pnu/momeet/common/config/S3Config.java
@@ -11,11 +11,11 @@ import software.amazon.awssdk.services.s3.S3Client;
 @Configuration
 public class S3Config {
 
-    @Value("${cloud.aws.credentials.access-key}")
+    @Value("${spring.cloud.aws.credentials.access-key}")
     private String accessKey;
-    @Value("${cloud.aws.credentials.secret-key}")
+    @Value("${spring.cloud.aws.credentials.secret-key}")
     private String secretKey;
-    @Value("${cloud.aws.region.static}")
+    @Value("${spring.cloud.aws.region.static}")
     private String region;
 
     @Bean

--- a/src/main/java/com/pnu/momeet/common/service/S3StorageService.java
+++ b/src/main/java/com/pnu/momeet/common/service/S3StorageService.java
@@ -26,7 +26,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 public class S3StorageService {
 
     private final S3Client s3Client;
-    @Value("${cloud.aws.s3.bucket}")
+    @Value("${spring.cloud.aws.s3.bucket}")
     private String bucket;
 
     public String uploadImage(MultipartFile multipartFile, String prefix) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,16 @@ spring:
       max-file-size: 5MB
       max-request-size: 5MB
 
+  cloud:
+    aws:
+      credentials:
+        access-key: ${AWS_IAM_ACCESS_KEY}
+        secret-key: ${AWS_IAM_SECRET_KEY}
+      s3:
+        bucket: ${AWS_S3_BUCKET_NAME}
+      region:
+        static: ap-northeast-2
+
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}
@@ -31,13 +41,3 @@ jwt:
   refresh-token:
     expiration: 604800
   issuer: momeet
-
-cloud:
-  aws:
-    credentials:
-      access-key: ${AWS_IAM_ACCESS_KEY}
-      secret-key: ${AWS_IAM_SECRET_KEY}
-    s3:
-      bucket: ${AWS_S3_BUCKET_NAME}
-    region:
-      static: ap-northeast-2


### PR DESCRIPTION
# Pull Request 템플릿

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 걸어주세요 -->
- Closes #(35)

## 💡 변경 이유
<!-- 왜 이 코드 변경이 필요했나요? 어떤 문제를 해결하거나 어떤 기능을 추가했나요? -->

`application.yml` 에 기존 `cloud.aws` 관련 설정 앞에 `spring` 키워드를 붙이지 않아 기본 bean factory에서 설정이 없다고 오류가 발생해서 기존 `cloud.aws` 관련 설정 앞에 `spring` 키워드를 붙임

## 📋 주요 변경사항
<!-- 구체적으로 어떤 것들이 변경되었는지 간단히 나열해주세요 -->
- application.yml의 cloud.aws → spring.cloud.aws 로 변경
- AWS region, S3 bucket, credentials 설정이 정상적으로 인식되도록 수정
- 관련 코드에서도 spring.cloud.aws 구조에 맞게 수정

## ⚠️ 발견된 위험이나 장애
<!-- 개발 중 발견된 문제점이나 주의할 부분이 있다면 작성해주세요 (없으면  삭제) -->


## 👀 리뷰 포인트
<!-- 리뷰어가 특별히 집중해서 봐야 할 부분을 알려주세요 -->
- 
- 

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 (없으면 삭제해도 됩니다) -->


## ✅ 테스트 완료 사항
<!-- 어떻게 테스트했는지 간단히 작성해주세요 -->
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인