### PR TITLE
Feature/28 모임 참가자 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,10 +99,6 @@ sourceSets {
     main.java.srcDirs += [ querydslDir ]
 }
 
-clean.doLast {
-    file(querydslDir).deleteDir()
-}
-
 tasks.named('test') {
     useJUnitPlatform()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -39,42 +39,68 @@ ext {
     AWS_VERSION = '3.4.0'
     JTS_VERSION = '1.20.0'
     HIBERNATE_SPATIAL_VERSION = '7.1.0.Final'
+    QUERY_DSL_VERSION = '5.1.0'
 }
 
 dependencies {
+    // Spring Boot 스타터
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // Spring Security 및 JWT
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation "me.paulschwarz:spring-dotenv:${DOTENV_VERSION}"
     implementation "io.jsonwebtoken:jjwt-api:${JJWT_VERSION}"
     runtimeOnly "io.jsonwebtoken:jjwt-impl:${JJWT_VERSION}"
     runtimeOnly "io.jsonwebtoken:jjwt-jackson:${JJWT_VERSION}"
 
-    implementation "io.awspring.cloud:spring-cloud-aws-starter-s3:${AWS_VERSION}"
-
+    // Thymeleaf 템플릿 엔진
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 
+    // AWS SDK
+    implementation "io.awspring.cloud:spring-cloud-aws-starter-s3:${AWS_VERSION}"
+
+    // 데이터베이스 관련
+    runtimeOnly 'org.postgresql:postgresql'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation "com.querydsl:querydsl-jpa:${QUERY_DSL_VERSION}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${QUERY_DSL_VERSION}:jakarta"
 
-    runtimeOnly 'com.h2database:h2'
-    runtimeOnly 'org.postgresql:postgresql'
-
+    // spatial 지원
     implementation "org.locationtech.jts:jts-core:${JTS_VERSION}"
     implementation "org.hibernate:hibernate-spatial:${HIBERNATE_SPATIAL_VERSION}"
-    implementation "org.orbisgis:h2gis:2.2.3"
+    implementation "com.querydsl:querydsl-spatial:${QUERY_DSL_VERSION}"
 
+    // 개발 편의성 도구
     compileOnly 'org.projectlombok:lombok'
+    implementation "me.paulschwarz:spring-dotenv:${DOTENV_VERSION}"
     annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+    // 테스트 관련
     testImplementation "io.rest-assured:rest-assured:${RESTASSURED_VERSION}"
     testImplementation "io.rest-assured:json-path:${RESTASSURED_VERSION}"
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+
+def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
+
+tasks.withType(JavaCompile).configureEach {
+    options.generatedSourceOutputDirectory.set(querydslDir)
+}
+
+sourceSets {
+    main.java.srcDirs += [ querydslDir ]
+}
+
+clean.doLast {
+    file(querydslDir).deleteDir()
 }
 
 tasks.named('test') {

--- a/src/main/java/com/pnu/momeet/common/config/QueryDslConfig.java
+++ b/src/main/java/com/pnu/momeet/common/config/QueryDslConfig.java
@@ -1,0 +1,14 @@
+package com.pnu.momeet.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/pnu/momeet/domain/meetup/controller/MeetupController.java
+++ b/src/main/java/com/pnu/momeet/domain/meetup/controller/MeetupController.java
@@ -5,6 +5,7 @@ import com.pnu.momeet.domain.meetup.dto.request.MeetupCreateRequest;
 import com.pnu.momeet.domain.meetup.dto.request.MeetupGeoSearchRequest;
 import com.pnu.momeet.domain.meetup.dto.request.MeetupPageRequest;
 import com.pnu.momeet.domain.meetup.dto.request.MeetupUpdateRequest;
+import com.pnu.momeet.domain.meetup.dto.response.MeetupDetail;
 import com.pnu.momeet.domain.meetup.dto.response.MeetupResponse;
 import com.pnu.momeet.domain.meetup.service.MeetupService;
 import jakarta.validation.Valid;
@@ -45,7 +46,7 @@ public class MeetupController {
 
     @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
     @GetMapping("/{meetupId}")
-    public ResponseEntity<MeetupResponse> meetupResponse(
+    public ResponseEntity<MeetupDetail> meetupResponse(
             @PathVariable UUID meetupId
     ) {
         return ResponseEntity.ok(meetupService.findById(meetupId));
@@ -53,15 +54,15 @@ public class MeetupController {
 
     @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
     @GetMapping("/me")
-    public ResponseEntity<MeetupResponse> meetupSelf(
+    public ResponseEntity<MeetupDetail> meetupSelf(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        return ResponseEntity.ok(meetupService.findByMemberId(userDetails.getMemberId()));
+        return ResponseEntity.ok(meetupService.findOwnedMeetupByMemberID(userDetails.getMemberId()));
     }
 
     @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
     @PostMapping
-    public ResponseEntity<MeetupResponse> createMeetup(
+    public ResponseEntity<MeetupDetail> createMeetup(
             @Valid @RequestBody  MeetupCreateRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails
             ) {
@@ -72,7 +73,7 @@ public class MeetupController {
 
     @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
     @PutMapping("/me")
-    public ResponseEntity<MeetupResponse> updateMeetup(
+    public ResponseEntity<MeetupDetail> updateMeetup(
             @Valid @RequestBody  MeetupUpdateRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {

--- a/src/main/java/com/pnu/momeet/domain/meetup/dto/response/MeetupDetail.java
+++ b/src/main/java/com/pnu/momeet/domain/meetup/dto/response/MeetupDetail.java
@@ -1,0 +1,29 @@
+package com.pnu.momeet.domain.meetup.dto.response;
+
+import com.pnu.momeet.domain.common.dto.response.LocationResponse;
+import com.pnu.momeet.domain.profile.dto.response.ProfileResponse;
+import com.pnu.momeet.domain.sigungu.dto.response.SigunguResponse;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record MeetupDetail(
+        UUID id,
+        String name,
+        String category,
+        String subCategory,
+        String description,
+        Integer participantCount,
+        Integer capacity,
+        Double scoreLimit,
+        ProfileResponse owner,
+        SigunguResponse sigungu,
+        LocationResponse location,
+        List<String> hashTags,
+        String status,
+        LocalDateTime endAt,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/com/pnu/momeet/domain/meetup/dto/response/MeetupResponse.java
+++ b/src/main/java/com/pnu/momeet/domain/meetup/dto/response/MeetupResponse.java
@@ -1,7 +1,6 @@
 package com.pnu.momeet.domain.meetup.dto.response;
 
 import com.pnu.momeet.domain.common.dto.response.LocationResponse;
-import com.pnu.momeet.domain.sigungu.dto.response.SigunguResponse;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -9,14 +8,15 @@ import java.util.UUID;
 
 public record MeetupResponse(
     UUID id,
+    UUID ownerProfileId,
+    Long sigunguCode,
     String name,
     String category,
     String subCategory,
     List<String> hashTags,
-    String description,
+    Integer participantCount,
     Integer capacity,
     Double scoreLimit,
-    SigunguResponse sigungu,
     LocationResponse location,
     String status,
     LocalDateTime endAt,

--- a/src/main/java/com/pnu/momeet/domain/meetup/entity/Meetup.java
+++ b/src/main/java/com/pnu/momeet/domain/meetup/entity/Meetup.java
@@ -72,7 +72,8 @@ public class Meetup extends BaseEntity {
     private LocalDateTime endAt;
 
     @OneToMany(mappedBy = "meetup", fetch = FetchType.LAZY,
-            cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+            cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, 
+            orphanRemoval = true)
     private List<Participant> participants = new ArrayList<>();
 
     @Builder

--- a/src/main/java/com/pnu/momeet/domain/meetup/entity/Meetup.java
+++ b/src/main/java/com/pnu/momeet/domain/meetup/entity/Meetup.java
@@ -5,6 +5,7 @@ import com.pnu.momeet.domain.common.entity.BaseEntity;
 import com.pnu.momeet.domain.meetup.enums.MainCategory;
 import com.pnu.momeet.domain.meetup.enums.MeetupStatus;
 import com.pnu.momeet.domain.meetup.enums.SubCategory;
+import com.pnu.momeet.domain.participant.entity.Participant;
 import com.pnu.momeet.domain.profile.entity.Profile;
 import com.pnu.momeet.domain.sigungu.entity.Sigungu;
 import jakarta.persistence.*;
@@ -37,11 +38,15 @@ public class Meetup extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private SubCategory subCategory;
 
-    @OneToMany(mappedBy = "meetup", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "meetup", fetch = FetchType.LAZY,
+            cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MeetupHashTag> hashTags = new ArrayList<>();
 
     @Column(name = "description", columnDefinition = "TEXT", nullable = false)
     private String description;
+
+    @Column(name = "participant_count", nullable = false)
+    private Integer participantCount = 1;
 
     @Column(name = "capacity", nullable = false)
     private Integer capacity = 10;
@@ -66,13 +71,16 @@ public class Meetup extends BaseEntity {
     @Column(name = "end_at")
     private LocalDateTime endAt;
 
+    @OneToMany(mappedBy = "meetup", fetch = FetchType.LAZY,
+            cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+    private List<Participant> participants = new ArrayList<>();
+
     @Builder
     public Meetup(
             Profile owner,
             String name,
             MainCategory category,
             SubCategory subCategory,
-            List<String> hashTags,
             String description,
             Integer capacity,
             Double scoreLimit,
@@ -85,7 +93,6 @@ public class Meetup extends BaseEntity {
         this.name = name;
         this.category = category;
         this.subCategory = subCategory;
-        setHashTags(hashTags);
         this.description = description;
         this.capacity = capacity;
         this.scoreLimit = scoreLimit;
@@ -100,5 +107,15 @@ public class Meetup extends BaseEntity {
         for (String tag : hashTags) {
             this.hashTags.add(new MeetupHashTag(tag, this));
         }
+    }
+
+    public void addParticipant(Participant participant) {
+        this.participants.add(participant);
+        participant.setMeetup(this);
+    }
+
+    public void removeParticipant(Participant participant) {
+        this.participants.remove(participant);
+        participant.setMeetup(null);
     }
 }

--- a/src/main/java/com/pnu/momeet/domain/meetup/repository/MeetupDslRepository.java
+++ b/src/main/java/com/pnu/momeet/domain/meetup/repository/MeetupDslRepository.java
@@ -4,7 +4,6 @@ import com.pnu.momeet.domain.meetup.entity.QMeetupHashTag;
 import com.pnu.momeet.domain.meetup.enums.MainCategory;
 import com.pnu.momeet.domain.meetup.enums.MeetupStatus;
 import com.pnu.momeet.domain.meetup.enums.SubCategory;
-import com.pnu.momeet.domain.profile.entity.Profile;
 import com.pnu.momeet.domain.sigungu.entity.QSigungu;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -15,7 +14,6 @@ import com.pnu.momeet.domain.meetup.entity.QMeetup;
 import com.pnu.momeet.domain.profile.entity.QProfile;
 import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Repository;
-import software.amazon.awssdk.services.s3.model.Owner;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/com/pnu/momeet/domain/meetup/repository/MeetupDslRepository.java
+++ b/src/main/java/com/pnu/momeet/domain/meetup/repository/MeetupDslRepository.java
@@ -90,18 +90,17 @@ public class MeetupDslRepository {
     public boolean existsByOwnerIdAndStatusIn(UUID memberId, List<MeetupStatus> statuses) {
         QMeetup meetup = QMeetup.meetup;
 
-        Long count =  jpaQueryFactory
-                .select(meetup.count())
+        Integer result = jpaQueryFactory
+                .selectOne()
                 .from(meetup)
                 .where(
                     meetup.owner.memberId.eq(memberId)
-                    .and(
-                        meetup.status.in(statuses)
-                    )
+                    .and(meetup.status.in(statuses))
                 )
-                .fetchOne();
+                .limit(1)
+                .fetchFirst();
 
-        return count != null && count > 0;
+        return result != null;
     }
 
     public Optional<Meetup> findByIdWithDetails(UUID meetupId) {

--- a/src/main/java/com/pnu/momeet/domain/meetup/repository/MeetupDslRepository.java
+++ b/src/main/java/com/pnu/momeet/domain/meetup/repository/MeetupDslRepository.java
@@ -1,0 +1,149 @@
+package com.pnu.momeet.domain.meetup.repository;
+
+import com.pnu.momeet.domain.meetup.entity.QMeetupHashTag;
+import com.pnu.momeet.domain.meetup.enums.MainCategory;
+import com.pnu.momeet.domain.meetup.enums.MeetupStatus;
+import com.pnu.momeet.domain.meetup.enums.SubCategory;
+import com.pnu.momeet.domain.profile.entity.Profile;
+import com.pnu.momeet.domain.sigungu.entity.QSigungu;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.pnu.momeet.domain.meetup.entity.Meetup;
+import com.pnu.momeet.domain.meetup.entity.QMeetup;
+import com.pnu.momeet.domain.profile.entity.QProfile;
+import org.locationtech.jts.geom.Point;
+import org.springframework.stereotype.Repository;
+import software.amazon.awssdk.services.s3.model.Owner;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public class MeetupDslRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+    public MeetupDslRepository(JPAQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+    private BooleanExpression distanceWithin(Point location, double radius) {
+        return Expressions.booleanTemplate(
+                "function('ST_DWithin', {0}, {1}, {2}) = true",
+                QMeetup.meetup.locationPoint,
+                location,
+                radius * 1000
+        );
+    }
+
+    public List<Meetup> findAllByDistanceAndPredicates(
+            Point location,
+            double radius,
+            Optional<MainCategory> category,
+            Optional<SubCategory> subCategory,
+            Optional<String> keyword
+    ) {
+        QMeetup meetup = QMeetup.meetup;
+        QProfile profile = QProfile.profile;
+        QMeetupHashTag hashTag = QMeetupHashTag.meetupHashTag;
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        builder.and(meetup.locationPoint.isNotNull());
+        builder.and(distanceWithin(location, radius));
+        builder.and(meetup.status.eq(MeetupStatus.OPEN));
+        category.ifPresent(mainCategory -> builder.and(meetup.category.eq(mainCategory)));
+        subCategory.ifPresent(subCat -> builder.and(meetup.subCategory.eq(subCat)));
+        keyword.ifPresent(kw -> builder.and(
+                meetup.name.containsIgnoreCase(kw)
+                .or(meetup.description.containsIgnoreCase(kw))
+        ));
+
+        return jpaQueryFactory
+                .selectFrom(meetup)
+                .leftJoin(meetup.owner, profile).fetchJoin()
+                .leftJoin(meetup.hashTags, hashTag).fetchJoin()
+                .where(builder)
+                .orderBy(meetup.createdAt.desc())
+                .fetch();
+    }
+
+    public Optional<Meetup> findOwnedMeetupByMemberId(UUID memberId) {
+        QMeetup meetup = QMeetup.meetup;
+
+        return Optional.ofNullable(
+                jpaQueryFactory
+                    .select(meetup)
+                    .from(meetup)
+                    .where(
+                        meetup.owner.memberId.eq(memberId)
+                        .and(
+                            meetup.status.eq(MeetupStatus.OPEN)
+                            .or(meetup.status.eq(MeetupStatus.IN_PROGRESS))
+                        )
+                    )
+                    .fetchOne()
+        );
+    }
+
+    public boolean existsByOwnerIdAndStatusIn(UUID memberId, List<MeetupStatus> statuses) {
+        QMeetup meetup = QMeetup.meetup;
+
+        Long count =  jpaQueryFactory
+                .select(meetup.count())
+                .from(meetup)
+                .where(
+                    meetup.owner.memberId.eq(memberId)
+                    .and(
+                        meetup.status.in(statuses)
+                    )
+                )
+                .fetchOne();
+
+        return count != null && count > 0;
+    }
+
+    public Optional<Meetup> findByIdWithDetails(UUID meetupId) {
+        QMeetup meetup = QMeetup.meetup;
+        QProfile profile = QProfile.profile;
+        QMeetupHashTag hashTag = QMeetupHashTag.meetupHashTag;
+        QSigungu sigungu = QSigungu.sigungu;
+
+        return Optional.ofNullable(
+                jpaQueryFactory
+                    .select(meetup)
+                    .from(meetup)
+                    .leftJoin(meetup.owner, profile).fetchJoin()
+                    .leftJoin(meetup.hashTags, hashTag).fetchJoin()
+                    .leftJoin(meetup.sigungu, sigungu).fetchJoin()
+                    .where(meetup.id.eq(meetupId))
+                    .fetchOne()
+        );
+    }
+
+
+    public Optional<Meetup> findOwnedMeetupByMemberIdWithDetails(UUID memberId) {
+        QMeetup meetup = QMeetup.meetup;
+        QProfile profile = QProfile.profile;
+        QMeetupHashTag hashTag = QMeetupHashTag.meetupHashTag;
+        QSigungu sigungu = QSigungu.sigungu;
+
+        return Optional.ofNullable(
+                jpaQueryFactory
+                    .select(meetup)
+                    .from(meetup)
+                    .leftJoin(meetup.owner, profile).fetchJoin()
+                    .leftJoin(meetup.hashTags, hashTag).fetchJoin()
+                    .leftJoin(meetup.sigungu, sigungu).fetchJoin()
+                    .where(
+                        meetup.owner.memberId.eq(memberId)
+                        .and(
+                            meetup.status.eq(MeetupStatus.OPEN)
+                            .or(meetup.status.eq(MeetupStatus.IN_PROGRESS))
+                        )
+                    )
+                    .fetchOne()
+        );
+    }
+}

--- a/src/main/java/com/pnu/momeet/domain/meetup/repository/MeetupRepository.java
+++ b/src/main/java/com/pnu/momeet/domain/meetup/repository/MeetupRepository.java
@@ -1,75 +1,19 @@
 package com.pnu.momeet.domain.meetup.repository;
 
 import com.pnu.momeet.domain.meetup.entity.Meetup;
-import com.pnu.momeet.domain.profile.entity.Profile;
-import org.locationtech.jts.geom.Point;
+import com.pnu.momeet.domain.meetup.enums.MeetupStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface MeetupRepository extends JpaRepository<Meetup, UUID>, JpaSpecificationExecutor<Meetup> {
-
-    @Query(value = """
-            SELECT * FROM meetup m
-            WHERE st_dwithin(m.location_point, :location, :radius * 1000) = true
-            AND m.status = 'OPEN'
-    """, nativeQuery = true)
-    List<Meetup> findAllByDistance(Point location, double radius);
-
-    @Query(value = """
-            SELECT * FROM meetup m
-            WHERE st_dwithin(m.location_point, :location, :radius * 1000) = true
-            AND m.status = 'OPEN'
-            AND m.category = :category
-    """, nativeQuery = true)
-    List<Meetup> findAllByDistanceAndCategory (Point location, double radius, String category);
-
-    @Query(value = """
-            SELECT * FROM meetup m
-            WHERE st_dwithin(m.location_point, :location, :radius * 1000) = true
-            AND m.status = 'OPEN'
-            AND m.sub_category = :subCategory
-    """, nativeQuery = true)
-    List<Meetup> findAllByDistanceAndSubCategory(Point location, double radius, String subCategory);
-
-    @Query(value = """
-            SELECT * FROM meetup m
-            WHERE st_dwithin(m.location_point, :location, :radius * 1000) = true
-            AND m.status = 'OPEN'
-            AND (
-                LOWER(m.name) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
-                LOWER(m.description) LIKE LOWER(CONCAT('%', :keyword, '%'))
-            )
-    """, nativeQuery = true)
-    List<Meetup> findAllByDistanceAndKeyword(Point location, double radius, String keyword);
-
-    @Query(value = """
-            SELECT * FROM meetup m
-            WHERE st_dwithin(m.location_point, :location, :radius * 1000) = true
-            AND m.status = 'OPEN'
-            AND m.category = :category
-            AND (
-                LOWER(m.name) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
-                LOWER(m.description) LIKE LOWER(CONCAT('%', :keyword, '%'))
-            )
-    """, nativeQuery = true)
-    List<Meetup> findAllByDistanceAndCategoryAndKeyword(Point location, double radius, String category, String keyword);
-
-    @Query(value = """
-            SELECT * FROM meetup m
-            WHERE st_dwithin(m.location_point, :location, :radius * 1000) = true
-            AND m.status = 'OPEN'
-            AND m.sub_category = :subCategory
-            AND (
-                LOWER(m.name) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
-                LOWER(m.description) LIKE LOWER(CONCAT('%', :keyword, '%'))
-            )
-    """, nativeQuery = true)
-    List<Meetup> findAllByDistanceAndSubCategoryAndKeyword(Point location, double radius, String subCategory, String keyword);
-
-    Optional<Meetup> findByOwner(Profile profile);
+    @EntityGraph(attributePaths = {"hashTags"})
+    Page<Meetup> findAll(Specification<Meetup> spec, Pageable pageable);
 }

--- a/src/main/java/com/pnu/momeet/domain/meetup/service/MeetupService.java
+++ b/src/main/java/com/pnu/momeet/domain/meetup/service/MeetupService.java
@@ -149,6 +149,7 @@ public class MeetupService {
                 .meetup(createdMeetup)
                 .profile(profile)
                 .role(MeetupRole.HOST)
+                .isActive(false)
                 .isRated(false)
                 .lastActiveAt(LocalDateTime.now())
                 .build();

--- a/src/main/java/com/pnu/momeet/domain/meetup/service/mapper/MeetupDtoMapper.java
+++ b/src/main/java/com/pnu/momeet/domain/meetup/service/mapper/MeetupDtoMapper.java
@@ -12,7 +12,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.domain.Specification;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.function.Consumer;
 
 public class MeetupDtoMapper {

--- a/src/main/java/com/pnu/momeet/domain/meetup/service/mapper/MeetupDtoMapper.java
+++ b/src/main/java/com/pnu/momeet/domain/meetup/service/mapper/MeetupDtoMapper.java
@@ -33,7 +33,6 @@ public class MeetupDtoMapper {
                 .name(request.name())
                 .category(category)
                 .subCategory(subCategory)
-                .hashTags(List.of())
                 .description(request.description())
                 .capacity(request.capacity())
                 .scoreLimit(request.scoreLimit())

--- a/src/main/java/com/pnu/momeet/domain/meetup/service/mapper/MeetupEntityMapper.java
+++ b/src/main/java/com/pnu/momeet/domain/meetup/service/mapper/MeetupEntityMapper.java
@@ -1,9 +1,11 @@
 package com.pnu.momeet.domain.meetup.service.mapper;
 
 import com.pnu.momeet.domain.common.dto.response.LocationResponse;
+import com.pnu.momeet.domain.meetup.dto.response.MeetupDetail;
 import com.pnu.momeet.domain.meetup.dto.response.MeetupResponse;
 import com.pnu.momeet.domain.meetup.entity.Meetup;
 import com.pnu.momeet.domain.meetup.entity.MeetupHashTag;
+import com.pnu.momeet.domain.profile.service.mapper.ProfileEntityMapper;
 import com.pnu.momeet.domain.sigungu.service.mapper.SigunguEntityMapper;
 
 import java.util.List;
@@ -15,7 +17,7 @@ public class MeetupEntityMapper {
     }
 
 
-    public static MeetupResponse toDto(Meetup meetup) {
+    public static MeetupResponse toResponse(Meetup meetup) {
         LocationResponse location = new LocationResponse(
                 meetup.getLocationPoint().getX(),
                 meetup.getLocationPoint().getY(),
@@ -25,18 +27,50 @@ public class MeetupEntityMapper {
         List<String> hashTags = meetup.getHashTags().stream()
                 .map(MeetupHashTag::getName)
                 .toList();
-        //TODO: 참가자 수 추후 구현
+
         return new MeetupResponse(
                 meetup.getId(),
+                meetup.getOwner().getId(),
+                meetup.getSigungu().getId(),
                 meetup.getName(),
                 meetup.getCategory().name(),
                 meetup.getSubCategory().name(),
                 hashTags,
-                meetup.getDescription(),
+                meetup.getParticipantCount(),
                 meetup.getCapacity(),
                 meetup.getScoreLimit(),
+                location,
+                meetup.getStatus().name(),
+                meetup.getEndAt(),
+                meetup.getCreatedAt(),
+                meetup.getUpdatedAt()
+        );
+    }
+
+    public static MeetupDetail toDetail(Meetup meetup) {
+        LocationResponse location = new LocationResponse(
+                meetup.getLocationPoint().getX(),
+                meetup.getLocationPoint().getY(),
+                meetup.getAddress()
+        );
+
+        List<String> hashTags = meetup.getHashTags().stream()
+                .map(MeetupHashTag::getName)
+                .toList();
+
+        return new MeetupDetail(
+                meetup.getId(),
+                meetup.getName(),
+                meetup.getCategory().name(),
+                meetup.getSubCategory().name(),
+                meetup.getDescription(),
+                meetup.getParticipantCount(),
+                meetup.getCapacity(),
+                meetup.getScoreLimit(),
+                ProfileEntityMapper.toResponseDto(meetup.getOwner()),
                 SigunguEntityMapper.toDto(meetup.getSigungu()),
                 location,
+                hashTags,
                 meetup.getStatus().name(),
                 meetup.getEndAt(),
                 meetup.getCreatedAt(),

--- a/src/main/java/com/pnu/momeet/domain/participant/controller/ParticipantController.java
+++ b/src/main/java/com/pnu/momeet/domain/participant/controller/ParticipantController.java
@@ -47,7 +47,7 @@ public class ParticipantController {
     }
 
     @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
-    @PostMapping("/grant/{participantId}")
+    @PatchMapping("/{participantId}/grant")
     public ResponseEntity<ParticipantResponse> grantRole(
             @PathVariable UUID meetupId,
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -59,7 +59,7 @@ public class ParticipantController {
     }
 
     @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
-    @PostMapping("/kick/{participantId}")
+    @DeleteMapping("/{participantId}")
     public ResponseEntity<Void> kickParticipant(
             @PathVariable UUID meetupId,
             @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/pnu/momeet/domain/participant/controller/ParticipantController.java
+++ b/src/main/java/com/pnu/momeet/domain/participant/controller/ParticipantController.java
@@ -1,0 +1,71 @@
+package com.pnu.momeet.domain.participant.controller;
+
+import com.pnu.momeet.common.security.details.CustomUserDetails;
+import com.pnu.momeet.domain.participant.dto.response.ParticipantResponse;
+import com.pnu.momeet.domain.participant.service.ParticipantService;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/meetups/{meetupId}/participants")
+@RequiredArgsConstructor
+public class ParticipantController {
+    private final ParticipantService participantService;
+
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
+    @GetMapping
+    public ResponseEntity<List<ParticipantResponse>> participantsList(
+            @PathVariable UUID meetupId
+    ) {
+        List<ParticipantResponse> participants = participantService.getParticipantsByMeetupId(meetupId);
+        return ResponseEntity.ok().body(participants);
+    }
+
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
+    @PostMapping
+    public ResponseEntity<ParticipantResponse> joinMeetup(
+            @PathVariable UUID meetupId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        ParticipantResponse response = participantService.joinMeetup(meetupId, userDetails.getMemberId());
+        return ResponseEntity.ok().body(response);
+    }
+
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
+    @DeleteMapping
+    public ResponseEntity<Void> leaveMeetup(
+            @PathVariable UUID meetupId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        participantService.leaveMeetup(meetupId, userDetails.getMemberId());
+        return ResponseEntity.noContent().build();
+    }
+
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
+    @PostMapping("/grant/{participantId}")
+    public ResponseEntity<ParticipantResponse> grantRole(
+            @PathVariable UUID meetupId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long participantId
+    ) {
+        ParticipantResponse response = participantService.
+                grantHostRole(meetupId, userDetails.getMemberId(), participantId);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
+    @PostMapping("/kick/{participantId}")
+    public ResponseEntity<Void> kickParticipant(
+            @PathVariable UUID meetupId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long participantId
+    ) {
+        participantService.kickParticipant(meetupId, userDetails.getMemberId(), participantId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/pnu/momeet/domain/participant/dto/response/ParticipantResponse.java
+++ b/src/main/java/com/pnu/momeet/domain/participant/dto/response/ParticipantResponse.java
@@ -8,6 +8,7 @@ public record ParticipantResponse(
         Long id,
         ProfileResponse profile,
         String role,
+        Boolean isActive,
         Boolean isRated,
         LocalDateTime lastActiveAt,
         LocalDateTime createdAt

--- a/src/main/java/com/pnu/momeet/domain/participant/dto/response/ParticipantResponse.java
+++ b/src/main/java/com/pnu/momeet/domain/participant/dto/response/ParticipantResponse.java
@@ -1,0 +1,15 @@
+package com.pnu.momeet.domain.participant.dto.response;
+
+import com.pnu.momeet.domain.profile.dto.response.ProfileResponse;
+
+import java.time.LocalDateTime;
+
+public record ParticipantResponse(
+        Long id,
+        ProfileResponse profile,
+        String role,
+        Boolean isRated,
+        LocalDateTime lastActiveAt,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/pnu/momeet/domain/participant/entity/Participant.java
+++ b/src/main/java/com/pnu/momeet/domain/participant/entity/Participant.java
@@ -29,7 +29,6 @@ public class Participant extends SimpleCreationEntity {
 
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "meetup_id", nullable = false)
     private Meetup meetup;
 

--- a/src/main/java/com/pnu/momeet/domain/participant/entity/Participant.java
+++ b/src/main/java/com/pnu/momeet/domain/participant/entity/Participant.java
@@ -1,0 +1,72 @@
+package com.pnu.momeet.domain.participant.entity;
+
+import com.pnu.momeet.domain.common.entity.SimpleCreationEntity;
+import com.pnu.momeet.domain.meetup.entity.Meetup;
+import com.pnu.momeet.domain.participant.enums.MeetupRole;
+import com.pnu.momeet.domain.profile.entity.Profile;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "meetup_participant")
+@NoArgsConstructor
+@NamedEntityGraph(
+    name = "Participant.withProfile",
+    attributeNodes = @NamedAttributeNode("profile")
+)
+public class Participant extends SimpleCreationEntity {
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "meetup_id", nullable = false)
+    private Meetup meetup;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "profile_id", nullable = false)
+    private Profile profile;
+
+    @Size(max = 20)
+    @NotNull
+    @ColumnDefault("'MEMBER'")
+    @Column(name = "role", nullable = false, length = 20)
+    @Enumerated(EnumType.STRING)
+    private MeetupRole role = MeetupRole.MEMBER;
+
+    @NotNull
+    @ColumnDefault("false")
+    @Column(name = "is_rated", nullable = false)
+    private Boolean isRated = false;
+
+    @Column(name = "last_active_at")
+    private LocalDateTime lastActiveAt;
+
+    @Builder
+    public Participant(
+            Meetup meetup,
+            Profile profile,
+            MeetupRole role,
+            Boolean isRated,
+            LocalDateTime lastActiveAt
+    ) {
+        this.meetup = meetup;
+        this.profile = profile;
+        this.role = role;
+        this.isRated = isRated;
+        this.lastActiveAt = lastActiveAt;
+    }
+}

--- a/src/main/java/com/pnu/momeet/domain/participant/entity/Participant.java
+++ b/src/main/java/com/pnu/momeet/domain/participant/entity/Participant.java
@@ -47,6 +47,11 @@ public class Participant extends SimpleCreationEntity {
 
     @NotNull
     @ColumnDefault("false")
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive = false;
+
+    @NotNull
+    @ColumnDefault("false")
     @Column(name = "is_rated", nullable = false)
     private Boolean isRated = false;
 
@@ -58,12 +63,14 @@ public class Participant extends SimpleCreationEntity {
             Meetup meetup,
             Profile profile,
             MeetupRole role,
+            Boolean isActive,
             Boolean isRated,
             LocalDateTime lastActiveAt
     ) {
         this.meetup = meetup;
         this.profile = profile;
         this.role = role;
+        this.isActive = isActive;
         this.isRated = isRated;
         this.lastActiveAt = lastActiveAt;
     }

--- a/src/main/java/com/pnu/momeet/domain/participant/entity/Participant.java
+++ b/src/main/java/com/pnu/momeet/domain/participant/entity/Participant.java
@@ -6,7 +6,6 @@ import com.pnu.momeet.domain.participant.enums.MeetupRole;
 import com.pnu.momeet.domain.profile.entity.Profile;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -40,7 +39,6 @@ public class Participant extends SimpleCreationEntity {
     @JoinColumn(name = "profile_id", nullable = false)
     private Profile profile;
 
-    @Size(max = 20)
     @NotNull
     @ColumnDefault("'MEMBER'")
     @Column(name = "role", nullable = false, length = 20)

--- a/src/main/java/com/pnu/momeet/domain/participant/enums/MeetupRole.java
+++ b/src/main/java/com/pnu/momeet/domain/participant/enums/MeetupRole.java
@@ -1,0 +1,6 @@
+package com.pnu.momeet.domain.participant.enums;
+
+public enum MeetupRole {
+    HOST, // 밋업 관리자
+    MEMBER  // 일반 참가자
+}

--- a/src/main/java/com/pnu/momeet/domain/participant/repository/ParticipantRepository.java
+++ b/src/main/java/com/pnu/momeet/domain/participant/repository/ParticipantRepository.java
@@ -1,0 +1,38 @@
+package com.pnu.momeet.domain.participant.repository;
+
+import com.pnu.momeet.domain.participant.entity.Participant;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ParticipantRepository extends JpaRepository<Participant, Long> {
+
+    @EntityGraph("Participant.withProfile")
+    List<Participant> findAllByMeetupId(UUID meetupId);
+
+    @Query("""
+        SELECT p FROM Participant p
+        WHERE p.meetup.id = :meetupId
+        ORDER BY p.profile.temperature DESC
+        LIMIT 2
+    """)
+    List<Participant> findTopTwoByOrderByTemperatureDesc(UUID meetupId);
+
+    Optional<Participant> findByProfileIdAndMeetupId(UUID profileId, UUID meetupId);
+
+    boolean existsByMeetupIdAndProfileId(UUID meetup_id, UUID profile_id);
+
+    boolean existsByIdAndMeetupId(Long id, UUID meetupId);
+
+    @Query("""
+        SELECT p FROM Participant p
+        WHERE p.meetup.id = :meetupId AND p.profile.memberId = :memberId
+    """)
+    Optional<Participant> findByMemberIdAndMeetupId(UUID memberId, UUID meetupId);
+
+    Long countByMeetupId(UUID meetupId);
+}

--- a/src/main/java/com/pnu/momeet/domain/participant/repository/ParticipantRepository.java
+++ b/src/main/java/com/pnu/momeet/domain/participant/repository/ParticipantRepository.java
@@ -22,6 +22,7 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
     """)
     List<Participant> findTopTwoByOrderByTemperatureDesc(UUID meetupId);
 
+    Optional<Participant> findByIdAndMeetupId(Long id, UUID meetupId);
     Optional<Participant> findByProfileIdAndMeetupId(UUID profileId, UUID meetupId);
 
     boolean existsByMeetupIdAndProfileId(UUID meetup_id, UUID profile_id);

--- a/src/main/java/com/pnu/momeet/domain/participant/repository/ParticipantRepository.java
+++ b/src/main/java/com/pnu/momeet/domain/participant/repository/ParticipantRepository.java
@@ -33,6 +33,4 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
         WHERE p.meetup.id = :meetupId AND p.profile.memberId = :memberId
     """)
     Optional<Participant> findByMemberIdAndMeetupId(UUID memberId, UUID meetupId);
-
-    Long countByMeetupId(UUID meetupId);
 }

--- a/src/main/java/com/pnu/momeet/domain/participant/service/ParticipantService.java
+++ b/src/main/java/com/pnu/momeet/domain/participant/service/ParticipantService.java
@@ -112,7 +112,7 @@ public class ParticipantService {
                 && participant.getRole() == MeetupRole.HOST) {
             Participant newHost = participants.get(1);
             newHost.setRole(MeetupRole.HOST);
-            meetup.setOwner(participants.get(0).getProfile()); // 모임의 owner도 변경
+            meetup.setOwner(newHost.getProfile()); // 모임의 owner도 변경
         }
 
         meetup.setParticipantCount(meetup.getParticipantCount() - 1);

--- a/src/main/java/com/pnu/momeet/domain/participant/service/ParticipantService.java
+++ b/src/main/java/com/pnu/momeet/domain/participant/service/ParticipantService.java
@@ -14,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.NoSuchElementException;

--- a/src/main/java/com/pnu/momeet/domain/participant/service/ParticipantService.java
+++ b/src/main/java/com/pnu/momeet/domain/participant/service/ParticipantService.java
@@ -1,0 +1,169 @@
+package com.pnu.momeet.domain.participant.service;
+
+import com.pnu.momeet.domain.meetup.entity.Meetup;
+import com.pnu.momeet.domain.meetup.enums.MeetupStatus;
+import com.pnu.momeet.domain.meetup.service.MeetupService;
+import com.pnu.momeet.domain.participant.dto.response.ParticipantResponse;
+import com.pnu.momeet.domain.participant.entity.Participant;
+import com.pnu.momeet.domain.participant.enums.MeetupRole;
+import com.pnu.momeet.domain.participant.repository.ParticipantRepository;
+import com.pnu.momeet.domain.participant.service.mapper.ParticipantEntityMapper;
+import com.pnu.momeet.domain.profile.entity.Profile;
+import com.pnu.momeet.domain.profile.service.ProfileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ParticipantService {
+    private final ParticipantRepository participantRepository;
+    private final MeetupService meetupService;
+    private final ProfileService profileService;
+
+    @Transactional(readOnly = true)
+    public List<ParticipantResponse> getParticipantsByMeetupId(UUID meetupId) {
+        return participantRepository.findAllByMeetupId(meetupId)
+                .stream()
+                .map(ParticipantEntityMapper::toDto)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public Participant getEntityByProfileIDAndMeetupID(UUID profileId, UUID meetupId) {
+        return participantRepository.findByProfileIdAndMeetupId(profileId, meetupId)
+                .orElseThrow(() -> new NoSuchElementException("참가자를 찾을 수 없습니다."));
+    }
+
+    @Transactional(readOnly = true)
+    public Participant getEntityByMemberIdAndMeetupId(UUID memberId, UUID meetupId) {
+        return participantRepository.findByMemberIdAndMeetupId(memberId, meetupId)
+                .orElseThrow(() -> new NoSuchElementException("참가자를 찾을 수 없습니다."));
+    }
+
+    @Transactional
+    public ParticipantResponse joinMeetup(UUID meetupId, UUID memberId, MeetupRole role) {
+        Profile profile = profileService.getProfileEntityByMemberId(memberId);
+
+        if (participantRepository.existsByMeetupIdAndProfileId(meetupId, profile.getId())) {
+            throw new IllegalStateException("이미 참여한 모임입니다.");
+        }
+
+        Meetup meetup = meetupService.findEntityById(meetupId);
+
+        if (meetup.getStatus() != MeetupStatus.OPEN) {
+            throw new IllegalStateException("모임에 참여할 수 없는 상태입니다. 현재 상태: "
+                    + meetup.getStatus().getDescription());
+        }
+        long currentParticipants = participantRepository.countByMeetupId(meetupId);
+
+        if (currentParticipants >= meetup.getCapacity()) {
+            throw new IllegalStateException("모임 정원이 초과되었습니다.");
+        }
+
+        Participant createdParticipant = Participant.builder()
+                .meetup(meetup)
+                .role(role)
+                .profile(profile)
+                .lastActiveAt(LocalDateTime.now())
+                .build();
+
+        return ParticipantEntityMapper.toDto(
+                participantRepository.save(createdParticipant)
+        );
+    }
+
+    @Transactional
+    public ParticipantResponse joinMeetup(UUID meetupId, UUID memberId) {
+        return joinMeetup(meetupId, memberId, MeetupRole.MEMBER);
+    }
+
+    @Transactional
+    public void leaveMeetup(UUID meetupId, UUID memberId) {
+        Profile profile = profileService.getProfileEntityByMemberId(memberId);
+        Meetup meetup = meetupService.findEntityById(meetupId);
+
+        Participant participant = getEntityByProfileIDAndMeetupID(profile.getId(), meetupId);
+        if (meetup.getStatus() != MeetupStatus.OPEN) {
+            throw new IllegalStateException("모임에서 나갈 수 없는 상태입니다. 현재 상태: "
+                    + meetup.getStatus().getDescription());
+        }
+
+        List<Participant> participants = participantRepository
+                .findTopTwoByOrderByTemperatureDesc(meetupId);
+
+        if (participants.size() <= 1) {
+            throw new IllegalStateException("참가자가 1명 이하인 모임에서 나갈 수 없습니다. 모임을 삭제하세요.");
+        }
+
+        // 호스트가 나갈 경우, 두 번째로 점수가 높은 참가자가 호스트가 됨
+        if (participants.get(0).getId().equals(participant.getId())
+                && participant.getRole() == MeetupRole.HOST) {
+            Participant newHost = participants.get(1);
+            newHost.setRole(MeetupRole.HOST);
+            meetup.setOwner(participants.get(0).getProfile()); // 모임의 owner도 변경
+        }
+
+        participantRepository.deleteById(participant.getId());
+    }
+
+    @Transactional
+    public void kickParticipant(UUID meetupId, UUID memberId, Long targetParticipantId) {
+        Participant requester = getEntityByMemberIdAndMeetupId(memberId, meetupId);
+        if (requester.getRole() != MeetupRole.HOST) {
+            throw new IllegalStateException("호스트만 참가자를 강퇴할 수 있습니다.");
+        }
+        if (requester.getId().equals(targetParticipantId)) {
+            throw new IllegalStateException("스스로를 강퇴할 수 없습니다.");
+        }
+        if (!participantRepository.existsByIdAndMeetupId(targetParticipantId, meetupId)) {
+            throw new NoSuchElementException("해당 참가자가 모임에 존재하지 않습니다.");
+        }
+        updateLastActiveAt(meetupId, memberId);
+        participantRepository.deleteById(targetParticipantId);
+    }
+
+    @Transactional
+    public ParticipantResponse grantHostRole(UUID meetupId, UUID memberId, Long targetParticipantId) {
+        Participant requester = getEntityByMemberIdAndMeetupId(memberId, meetupId);
+        if (requester.getRole() != MeetupRole.HOST) {
+            throw new IllegalStateException("호스트만 호스트 권한을 양도할 수 있습니다.");
+        }
+        if (requester.getId().equals(targetParticipantId)) {
+            throw new IllegalStateException("스스로에게 호스트 권한을 양도할 수 없습니다.");
+        }
+        Participant targetParticipant = participantRepository.findById(targetParticipantId)
+                .orElseThrow(() -> new NoSuchElementException("해당 참가자가 모임에 존재하지 않습니다."));
+
+        if (!targetParticipant.getMeetup().getId().equals(meetupId)) {
+            throw new IllegalStateException("해당 참가자가 이 모임의 참가자가 아닙니다.");
+        }
+        if (targetParticipant.getRole() == MeetupRole.HOST) {
+            throw new IllegalStateException("이미 호스트인 참가자에게 호스트 권한을 양도할 수 없습니다.");
+        }
+
+        // 기존 호스트를 MEMBER로 변경
+        requester.setRole(MeetupRole.MEMBER);
+        // 새로운 호스트를 HOST로 변경
+        targetParticipant.setRole(MeetupRole.HOST);
+        // 모임의 owner도 변경
+        Meetup meetup = targetParticipant.getMeetup();
+        meetup.setOwner(targetParticipant.getProfile());
+        // 활동 시간 업데이트
+        updateLastActiveAt(meetupId, memberId);
+
+        return ParticipantEntityMapper.toDto(targetParticipant);
+    }
+
+    @Transactional
+    public void updateLastActiveAt(UUID meetupId, UUID memberId) {
+        Participant participant = getEntityByMemberIdAndMeetupId(memberId, meetupId);
+        participant.setLastActiveAt(LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/pnu/momeet/domain/participant/service/ParticipantService.java
+++ b/src/main/java/com/pnu/momeet/domain/participant/service/ParticipantService.java
@@ -60,9 +60,7 @@ public class ParticipantService {
             throw new IllegalStateException("모임에 참여할 수 없는 상태입니다. 현재 상태: "
                     + meetup.getStatus().getDescription());
         }
-        long currentParticipants = participantRepository.countByMeetupId(meetupId);
-
-        if (currentParticipants >= meetup.getCapacity()) {
+        if (meetup.getParticipantCount() >= meetup.getCapacity()) {
             throw new IllegalStateException("모임 정원이 초과되었습니다.");
         }
 
@@ -72,6 +70,9 @@ public class ParticipantService {
                 .profile(profile)
                 .lastActiveAt(LocalDateTime.now())
                 .build();
+
+        meetup.addParticipant(createdParticipant); // 양방향 연관관계 설정
+        meetup.setParticipantCount(meetup.getParticipantCount() + 1);
 
         return ParticipantEntityMapper.toDto(
                 participantRepository.save(createdParticipant)
@@ -108,6 +109,9 @@ public class ParticipantService {
             newHost.setRole(MeetupRole.HOST);
             meetup.setOwner(participants.get(0).getProfile()); // 모임의 owner도 변경
         }
+
+        meetup.setParticipantCount(meetup.getParticipantCount() - 1);
+        meetup.removeParticipant(participant); // 양방향 연관관계 설정 해제
 
         participantRepository.deleteById(participant.getId());
     }

--- a/src/main/java/com/pnu/momeet/domain/participant/service/ParticipantService.java
+++ b/src/main/java/com/pnu/momeet/domain/participant/service/ParticipantService.java
@@ -71,6 +71,7 @@ public class ParticipantService {
                 .meetup(meetup)
                 .role(role)
                 .profile(profile)
+                .isActive(false)
                 .isRated(false)
                 .lastActiveAt(LocalDateTime.now())
                 .build();

--- a/src/main/java/com/pnu/momeet/domain/participant/service/mapper/ParticipantEntityMapper.java
+++ b/src/main/java/com/pnu/momeet/domain/participant/service/mapper/ParticipantEntityMapper.java
@@ -12,6 +12,7 @@ public class ParticipantEntityMapper {
                 participant.getId(),
                 ProfileEntityMapper.toResponseDto(participant.getProfile()),
                 participant.getRole().name(),
+                participant.getIsActive(),
                 participant.getIsRated(),
                 participant.getLastActiveAt(),
                 participant.getCreatedAt()

--- a/src/main/java/com/pnu/momeet/domain/participant/service/mapper/ParticipantEntityMapper.java
+++ b/src/main/java/com/pnu/momeet/domain/participant/service/mapper/ParticipantEntityMapper.java
@@ -1,0 +1,20 @@
+package com.pnu.momeet.domain.participant.service.mapper;
+
+import com.pnu.momeet.domain.participant.dto.response.ParticipantResponse;
+import com.pnu.momeet.domain.participant.entity.Participant;
+import com.pnu.momeet.domain.profile.service.mapper.ProfileEntityMapper;
+
+public class ParticipantEntityMapper {
+    private ParticipantEntityMapper() {}
+
+    public static ParticipantResponse toDto(Participant participant) {
+        return new ParticipantResponse(
+                participant.getId(),
+                ProfileEntityMapper.toResponseDto(participant.getProfile()),
+                participant.getRole().name(),
+                participant.getIsRated(),
+                participant.getLastActiveAt(),
+                participant.getCreatedAt()
+        );
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,21 +28,10 @@ spring:
     hibernate:
       ddl-auto: update
     defer-datasource-initialization: true
-
-  cloud:
-    aws:
-      region:
-        static: ap-northeast-2
-
   sql:
     init:
       mode: always
       data-locations: classpath:sql/init_scheme.sql, classpath:sql/init_data.sql
-
-  cloud:
-    aws:
-      region:
-        static: ap-northeast-2
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/main/resources/sql/init_data.sql
+++ b/src/main/resources/sql/init_data.sql
@@ -88,6 +88,15 @@ VALUES (
         now() + interval '8 hours'
 );
 
+INSERT INTO meetup_participant (meetup_id, profile_id, role, last_active_at)
+VALUES (
+        (SELECT id FROM meetup WHERE owner_id = (SELECT id FROM profile WHERE member_id = (SELECT id FROM member WHERE email = 'alice@test.com'))),
+        (SELECT id FROM profile WHERE member_id = (SELECT id FROM member WHERE email = 'alice@test.com')),
+        'HOST',
+        now()
+);
+
+
 INSERT INTO meetup(owner_id, name, category, sub_category,description,capacity,score_limit,location_point,address,sgg_code,status,end_at)
 VALUES (
         (SELECT id FROM profile WHERE member_id = (SELECT id FROM member WHERE email = 'chris@test.com')),
@@ -104,4 +113,10 @@ VALUES (
         now() + interval '10 hours'
 );
 
-
+INSERT INTO meetup_participant (meetup_id, profile_id, role, last_active_at)
+VALUES (
+        (SELECT id FROM meetup WHERE owner_id = (SELECT id FROM profile WHERE member_id = (SELECT id FROM member WHERE email = 'chris@test.com'))),
+        (SELECT id FROM profile WHERE member_id = (SELECT id FROM member WHERE email = 'chris@test.com')),
+        'HOST',
+        now()
+);

--- a/src/main/resources/sql/init_scheme.sql
+++ b/src/main/resources/sql/init_scheme.sql
@@ -108,6 +108,7 @@ CREATE TABLE meetup_participant (
     meetup_id       UUID NOT NULL REFERENCES meetup(id) ON DELETE CASCADE,
     profile_id      UUID NOT NULL REFERENCES profile(id) ON DELETE CASCADE,
     role            VARCHAR(20) NOT NULL DEFAULT 'MEMBER',
+    is_active       BOOLEAN NOT NULL DEFAULT FALSE,
     is_rated        BOOLEAN NOT NULL DEFAULT FALSE,
     last_active_at  TIMESTAMP,
     created_at      TIMESTAMP   NOT NULL DEFAULT NOW(),

--- a/src/main/resources/sql/init_scheme.sql
+++ b/src/main/resources/sql/init_scheme.sql
@@ -5,6 +5,7 @@ DROP TABLE IF EXISTS profile CASCADE;
 DROP TABLE IF EXISTS member CASCADE;
 DROP TABLE IF EXISTS meetup CASCADE;
 DROP TABLE IF EXISTS meetup_hash_tag CASCADE;
+DROP TABLE IF EXISTS meetup_participant CASCADE;
 
 CREATE TABLE member (
     id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -101,3 +102,16 @@ CREATE TABLE meetup_hash_tag (
     created_at      TIMESTAMP   NOT NULL DEFAULT NOW()
 );
 
+CREATE TABLE meetup_participant (
+    id              BIGSERIAL PRIMARY KEY,
+    meetup_id       UUID NOT NULL REFERENCES meetup(id) ON DELETE CASCADE,
+    profile_id      UUID NOT NULL REFERENCES profile(id) ON DELETE CASCADE,
+    role            VARCHAR(20) NOT NULL DEFAULT 'MEMBER',
+    is_rated        BOOLEAN NOT NULL DEFAULT FALSE,
+    last_active_at  TIMESTAMP,
+    created_at      TIMESTAMP   NOT NULL DEFAULT NOW(),
+    UNIQUE(meetup_id, profile_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_meetup_participant_meetup ON meetup_participant (meetup_id);
+CREATE INDEX IF NOT EXISTS idx_meetup_participant_profile ON meetup_participant (profile_id);

--- a/src/main/resources/sql/init_scheme.sql
+++ b/src/main/resources/sql/init_scheme.sql
@@ -78,6 +78,7 @@ CREATE TABLE meetup (
     category        VARCHAR(30) NOT NULL,
     sub_category    VARCHAR(30) NOT NULL,
     description     TEXT        NOT NULL,
+    participant_count INTEGER     NOT NULL DEFAULT 1,
     capacity        INTEGER     NOT NULL DEFAULT 10,
     score_limit     DOUBLE PRECISION NOT NULL DEFAULT 36.5,
     location_point  geography(Point, 4326) NOT NULL,

--- a/src/test/java/com/pnu/momeet/e2e/meetup/MeetupCreateTest.java
+++ b/src/test/java/com/pnu/momeet/e2e/meetup/MeetupCreateTest.java
@@ -2,7 +2,7 @@ package com.pnu.momeet.e2e.meetup;
 
 import com.pnu.momeet.domain.meetup.dto.request.LocationRequest;
 import com.pnu.momeet.domain.meetup.dto.request.MeetupCreateRequest;
-import com.pnu.momeet.domain.meetup.dto.response.MeetupResponse;
+import com.pnu.momeet.domain.meetup.dto.response.MeetupDetail;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.DisplayName;
@@ -66,7 +66,7 @@ class MeetupCreateTest extends BaseMeetupTest {
                     "endAt", notNullValue()
                 )
                 .extract()
-                .as(MeetupResponse.class);
+                .as(MeetupDetail.class);
 
         // 삭제할 모임 목록에 추가
         toBeDeleted.add(res.id());
@@ -114,7 +114,7 @@ class MeetupCreateTest extends BaseMeetupTest {
                     "status", equalTo("OPEN")
                 )
                 .extract()
-                .as(MeetupResponse.class);
+                .as(MeetupDetail.class);
 
         toBeDeleted.add(res.id());
     }

--- a/src/test/java/com/pnu/momeet/e2e/meetup/MeetupDeleteTest.java
+++ b/src/test/java/com/pnu/momeet/e2e/meetup/MeetupDeleteTest.java
@@ -2,10 +2,8 @@ package com.pnu.momeet.e2e.meetup;
 
 import com.pnu.momeet.domain.meetup.dto.request.LocationRequest;
 import com.pnu.momeet.domain.meetup.dto.request.MeetupCreateRequest;
-import com.pnu.momeet.domain.meetup.dto.response.MeetupResponse;
 import com.pnu.momeet.domain.member.enums.Role;
 import io.restassured.RestAssured;
-import io.restassured.http.ContentType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -23,7 +21,6 @@ class MeetupDeleteTest extends BaseMeetupTest {
                 129.08262659183725,
                 "부산광역시 금정구 부산대학로 63번길 2"
         );
-
         MeetupCreateRequest request = new MeetupCreateRequest(
                 "삭제 테스트 모임",
                 "GAME",
@@ -35,18 +32,7 @@ class MeetupDeleteTest extends BaseMeetupTest {
                 3,
                 location
         );
-
-        var response = RestAssured
-            .given()
-                .header(AUTH_HEADER, BEAR_PREFIX + userTokens.get(ALICE_EMAIL).accessToken())
-                .contentType(ContentType.JSON)
-                .body(request)
-            .when()
-                .post()
-            .then()
-                .statusCode(201)
-                .extract()
-                .as(MeetupResponse.class);
+        var response = meetupService.createMeetup(request, users.get(ALICE_EMAIL).id());
 
         // 삭제 테스트에서는 자동 정리 목록에 추가하지 않음 (직접 삭제 테스트하므로)
         return response.id();

--- a/src/test/java/com/pnu/momeet/e2e/meetup/MeetupUpdateTest.java
+++ b/src/test/java/com/pnu/momeet/e2e/meetup/MeetupUpdateTest.java
@@ -3,7 +3,6 @@ package com.pnu.momeet.e2e.meetup;
 import com.pnu.momeet.domain.meetup.dto.request.LocationRequest;
 import com.pnu.momeet.domain.meetup.dto.request.MeetupCreateRequest;
 import com.pnu.momeet.domain.meetup.dto.request.MeetupUpdateRequest;
-import com.pnu.momeet.domain.meetup.dto.response.MeetupResponse;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.DisplayName;
@@ -12,7 +11,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.stream.IntStream;
 
 import static org.hamcrest.Matchers.*;
@@ -21,7 +19,7 @@ import static org.hamcrest.Matchers.*;
 @DisplayName("E2E : Meetup 수정 테스트")
 class MeetupUpdateTest extends BaseMeetupTest {
 
-    private UUID createTestMeetup() {
+    private void createTestMeetup() {
         LocationRequest location = LocationRequest.of(
                 35.23203443995263,
                 129.08262659183725,
@@ -40,20 +38,8 @@ class MeetupUpdateTest extends BaseMeetupTest {
                 location
         );
 
-        var response = RestAssured
-            .given()
-                .header(AUTH_HEADER, BEAR_PREFIX + userTokens.get(ALICE_EMAIL).accessToken())
-                .contentType(ContentType.JSON)
-                .body(request)
-            .when()
-                .post()
-            .then()
-                .statusCode(201)
-                .extract()
-                .as(MeetupResponse.class);
-
+        var response = meetupService.createMeetup(request, users.get(ALICE_EMAIL).id());
         toBeDeleted.add(response.id());
-        return response.id();
     }
 
     @Test

--- a/src/test/java/com/pnu/momeet/e2e/participant/BaseParticipantTest.java
+++ b/src/test/java/com/pnu/momeet/e2e/participant/BaseParticipantTest.java
@@ -1,0 +1,141 @@
+package com.pnu.momeet.e2e.participant;
+
+import com.pnu.momeet.domain.auth.dto.response.TokenResponse;
+import com.pnu.momeet.domain.auth.service.EmailAuthService;
+import com.pnu.momeet.domain.meetup.dto.request.LocationRequest;
+import com.pnu.momeet.domain.meetup.dto.request.MeetupCreateRequest;
+import com.pnu.momeet.domain.meetup.dto.response.MeetupDetail;
+import com.pnu.momeet.domain.meetup.service.MeetupService;
+import com.pnu.momeet.domain.member.dto.response.MemberResponse;
+import com.pnu.momeet.domain.member.entity.Member;
+import com.pnu.momeet.domain.member.enums.Role;
+import com.pnu.momeet.domain.member.service.MemberService;
+import com.pnu.momeet.domain.profile.entity.Profile;
+import com.pnu.momeet.domain.profile.enums.Gender;
+import com.pnu.momeet.domain.profile.repository.ProfileRepository;
+import com.pnu.momeet.e2e.BaseE2ETest;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public abstract class BaseParticipantTest extends BaseE2ETest {
+    protected static final int TEST_USER_COUNT = 5;
+
+    protected List<String> emails;
+    protected List<MemberResponse> members;
+    protected List<Profile> profiles;
+    protected List<TokenResponse> tokens;
+    protected Map<Integer, MeetupDetail> meetups;
+
+    @Autowired
+    protected EmailAuthService emailAuthService;
+    @Autowired
+    protected MemberService memberService;
+    @Autowired
+    protected ProfileRepository profileRepository;
+    @Autowired
+    protected MeetupService meetupService;
+
+    @BeforeEach
+    @Override
+    protected void setup() {
+        super.setup();
+        RestAssured.basePath = "/api/meetups";
+
+        emails = new ArrayList<>();
+        members = new ArrayList<>();
+        profiles = new ArrayList<>();
+        tokens = new ArrayList<>();
+        meetups = new HashMap<>();
+
+        for (int i = 0; i < TEST_USER_COUNT; i++) {
+            createTestcase();
+        }
+    }
+
+    @AfterEach
+    protected void teardown() {
+        // 먼저 모든 meetup 삭제
+        if (meetups != null) {
+            for (MeetupDetail meetup : meetups.values()) {
+                try {
+                    meetupService.deleteMeetupAdmin(meetup.id());
+                } catch (Exception e) {
+                    // 이미 삭제되었거나 오류가 발생한 경우 무시
+                }
+            }
+            meetups.clear();
+        }
+        
+        // 그 다음 profile 삭제
+        if (profiles != null) {
+            for (int i = profiles.size() - 1; i >= 0; i--) {
+                try {
+                    profileRepository.delete(profiles.get(i));
+                } catch (Exception e) {
+                    // 이미 삭제되었거나 오류가 발생한 경우 무시
+                }
+            }
+            profiles.clear();
+        }
+        
+        // 마지막으로 member 삭제
+        if (members != null) {
+            for (int i = members.size() - 1; i >= 0; i--) {
+                try {
+                    memberService.deleteMemberById(members.get(i).id());
+                } catch (Exception e) {
+                    // 이미 삭제되었거나 오류가 발생한 경우 무시
+                }
+            }
+            members.clear();
+        }
+        
+        if (emails != null) emails.clear();
+        if (tokens != null) tokens.clear();
+    }
+
+    protected void createTestcase() {
+        String email = UUID.randomUUID().toString().substring(0, 8) + "@test.com";
+        emails.add(email);
+        members.add(memberService.saveMember(new Member(
+                email, TEST_USER_PASSWORD, List.of(Role.ROLE_USER)
+        )));
+        tokens.add(emailAuthService.login(email, TEST_USER_PASSWORD));
+        profiles.add(profileRepository.save(Profile.create(
+                members.getLast().id(),
+                UUID.randomUUID().toString().substring(0, 5) + "User",
+                25,
+                Gender.MALE,
+                "www.example.com/image.png",
+                "테스트 소개",
+                "부산시 금정구"
+        )));
+    }
+
+    protected MeetupDetail createTestMeetup(int index) {
+        MeetupCreateRequest request = new MeetupCreateRequest(
+                "테스트 밋업 " + index,
+                "STUDY",
+                "CERTIFICATE",
+                "테스트 밋업 설명",
+                List.of("테스트", "밋업", "해시태그" + index),
+                10,
+                10.0,
+                10,
+                new LocationRequest(35.243322, 129.088287, "부산시 금정구")
+        );
+
+        MeetupDetail meetup = meetupService.createMeetup(request, members.get(index).id());
+        meetups.put(index, meetup);
+        return meetup;
+    }
+
+}

--- a/src/test/java/com/pnu/momeet/e2e/participant/ParticipantJoinTest.java
+++ b/src/test/java/com/pnu/momeet/e2e/participant/ParticipantJoinTest.java
@@ -1,0 +1,152 @@
+package com.pnu.momeet.e2e.participant;
+
+import com.pnu.momeet.domain.meetup.dto.response.MeetupDetail;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@Tag("participant")
+@DisplayName("E2E : 밋업 참가 테스트")
+public class ParticipantJoinTest extends BaseParticipantTest {
+
+
+    @Test
+    @DisplayName("밋업 참가 성공 - 200 OK")
+    void joinMeetup_success() {
+        // Given: 밋업 생성
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        // When & Then: 다른 사용자가 밋업에 참가
+        given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .body("profile.nickname", equalTo(profiles.get(1).getNickname()))
+                .body("role", equalTo("MEMBER"))
+                .body("isRated", equalTo(false));
+    }
+
+    @Test
+    @DisplayName("여러 사용자 밋업 참가 성공 - 200 OK")
+    void joinMeetup_multipleUsers_success() {
+        // Given: 밋업 생성
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        // When & Then: 여러 사용자가 순차적으로 참가
+        for (int i = 1; i < TEST_USER_COUNT; i++) {
+            given()
+                    .header("Authorization", "Bearer " + tokens.get(i).accessToken())
+                    .pathParam("meetupId", meetup.id())
+            .when()
+                    .post("/{meetupId}/participants")
+            .then()
+                    .log().all()
+                    .statusCode(200)
+                    .body("profile.nickname", equalTo(profiles.get(i).getNickname()))
+                    .body("role", equalTo("MEMBER"));
+        }
+    }
+
+    @Test
+    @DisplayName("중복 참가 실패 - 409 Conflict")
+    void joinMeetup_duplicate_fail() {
+        // Given: 밋업 생성 및 사용자 참가
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200);
+        
+        // When & Then: 같은 사용자가 다시 참가 시도
+        given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(409); // Conflict
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 밋업 참가 실패 - 404 Not Found")
+    void joinMeetup_nonExistentMeetup_fail() {
+        // Given: 존재하지 않는 밋업 ID
+        String nonExistentMeetupId = "00000000-0000-0000-0000-000000000000";
+        
+        // When & Then: 존재하지 않는 밋업에 참가 시도
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", nonExistentMeetupId)
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(404); // Not Found
+    }
+
+    @Test
+    @DisplayName("미인증 사용자 참가 실패 - 401 Unauthorized")
+    void joinMeetup_unauthenticated_fail() {
+        // Given: 밋업 생성
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        // When & Then: 인증 토큰 없이 참가 시도
+        given()
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(401); // Unauthorized
+    }
+
+    @Test
+    @DisplayName("잘못된 토큰으로 참가 실패 - 401 Unauthorized")
+    void joinMeetup_invalidToken_fail() {
+        // Given: 밋업 생성
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        // When & Then: 잘못된 토큰으로 참가 시도
+        given()
+                .header("Authorization", "Bearer invalid_token")
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(401); // Unauthorized
+    }
+
+    @Test
+    @DisplayName("밋업 호스트 자동 참가 확인 - 200 OK")
+    void joinMeetup_hostAutoParticipation_success() {
+        // Given: 밋업 생성
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        // When & Then: 참가자 목록 조회 시 호스트가 HOST 역할로 포함되어 있음
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .get("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .body("size()", equalTo(1))
+                .body("[0].profile.nickname", equalTo(profiles.get(0).getNickname()))
+                .body("[0].role", equalTo("HOST"));
+    }
+}

--- a/src/test/java/com/pnu/momeet/e2e/participant/ParticipantKickTest.java
+++ b/src/test/java/com/pnu/momeet/e2e/participant/ParticipantKickTest.java
@@ -1,0 +1,401 @@
+package com.pnu.momeet.e2e.participant;
+
+import com.pnu.momeet.domain.meetup.dto.response.MeetupDetail;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@Tag("participant")
+@DisplayName("E2E : 참가자 강퇴 테스트")
+public class ParticipantKickTest extends BaseParticipantTest {
+
+
+    @Test
+    @DisplayName("참가자 강퇴 성공 - 204 No Content")
+    void kickParticipant_success() {
+        // Given: 밋업 생성 및 사용자 참가
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        Response joinResponse = given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .extract().response();
+        
+        Long participantId = joinResponse.jsonPath().getLong("id");
+        
+        // When & Then: 호스트가 참가자를 강퇴
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", meetup.id())
+                .pathParam("participantId", participantId)
+        .when()
+                .delete("/{meetupId}/participants/{participantId}")
+        .then()
+                .log().all()
+                .statusCode(204); // No Content
+        
+        // 참가자 목록에서 제거되었는지 확인
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .get("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .body("size()", equalTo(1)) // 호스트만 남음
+                .body("[0].profile.nickname", equalTo(profiles.get(0).getNickname()))
+                .body("profile.nickname", not(hasItem(profiles.get(1).getNickname())));
+    }
+
+    @Test
+    @DisplayName("특정 참가자만 강퇴 성공 - 204 No Content")
+    void kickParticipant_specific_success() {
+        // Given: 밋업 생성 및 여러 사용자 참가
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        // 세 명의 사용자가 밋업에 참가
+        given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200);
+        
+        Response joinResponse = given()
+                .header("Authorization", "Bearer " + tokens.get(2).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .extract().response();
+        
+        given()
+                .header("Authorization", "Bearer " + tokens.get(3).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200);
+        
+        Long participantToKickId = joinResponse.jsonPath().getLong("id");
+        
+        // When: 호스트가 특정 참가자를 강퇴
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", meetup.id())
+                .pathParam("participantId", participantToKickId)
+        .when()
+                .delete("/{meetupId}/participants/{participantId}")
+        .then()
+                .log().all()
+                .statusCode(204);
+        
+        // Then: 강퇴된 참가자만 제거되고 나머지는 유지
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .get("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .body("size()", equalTo(3)) // 호스트 + 2명 참가자
+                .body("profile.nickname", hasItems(
+                        profiles.get(0).getNickname(),
+                        profiles.get(1).getNickname(),
+                        profiles.get(3).getNickname()
+                ))
+                .body("profile.nickname", not(hasItem(profiles.get(2).getNickname())));
+    }
+
+    @Test
+    @DisplayName("일반 참가자 강퇴 시도 실패 - 403 Forbidden")
+    void kickParticipant_regularParticipant_fail() {
+        // Given: 밋업 생성 및 여러 사용자 참가
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200);
+        
+        Response joinResponse = given()
+                .header("Authorization", "Bearer " + tokens.get(2).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .extract().response();
+        
+        Long participantId = joinResponse.jsonPath().getLong("id");
+        
+        // When & Then: 일반 참가자가 다른 참가자를 강퇴 시도
+        given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+                .pathParam("participantId", participantId)
+        .when()
+                .delete("/{meetupId}/participants/{participantId}")
+        .then()
+                .log().all()
+                .statusCode(403); // Forbidden - 권한 없음
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 참가자 강퇴 실패 - 404 Not Found")
+    void kickParticipant_nonExistent_fail() {
+        // Given: 밋업 생성
+        MeetupDetail meetup = createTestMeetup(0);
+        Long nonExistentParticipantId = 99999L;
+        
+        // When & Then: 존재하지 않는 참가자를 강퇴 시도
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", meetup.id())
+                .pathParam("participantId", nonExistentParticipantId)
+        .when()
+                .delete("/{meetupId}/participants/{participantId}")
+        .then()
+                .log().all()
+                .statusCode(404); // Not Found
+    }
+
+    @Test
+    @DisplayName("호스트 자신 강퇴 실패 - 400 Bad Request")
+    void kickParticipant_hostSelf_fail() {
+        // Given: 밋업 생성
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        // 호스트의 참가자 ID 조회
+        Response participantsResponse = given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .get("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .extract().response();
+        
+        Long hostParticipantId = participantsResponse.jsonPath().getLong("find { it.role == 'HOST' }.id");
+        
+        // When & Then: 호스트가 자신을 강퇴 시도
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", meetup.id())
+                .pathParam("participantId", hostParticipantId)
+        .when()
+                .delete("/{meetupId}/participants/{participantId}")
+        .then()
+                .log().all()
+                .statusCode(400); // Bad Request - 호스트는 자신을 강퇴할 수 없음
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 밋업 강퇴 실패 - 404 Not Found")
+    void kickParticipant_nonExistentMeetup_fail() {
+        // Given: 존재하지 않는 밋업 ID
+        String nonExistentMeetupId = "00000000-0000-0000-0000-000000000000";
+        Long participantId = 1L;
+        
+        // When & Then: 존재하지 않는 밋업에서 강퇴 시도
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", nonExistentMeetupId)
+                .pathParam("participantId", participantId)
+        .when()
+                .delete("/{meetupId}/participants/{participantId}")
+        .then()
+                .log().all()
+                .statusCode(404); // Not Found
+    }
+
+    @Test
+    @DisplayName("미인증 사용자 강퇴 실패 - 401 Unauthorized")
+    void kickParticipant_unauthenticated_fail() {
+        // Given: 밋업 생성 및 사용자 참가
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        Response joinResponse = given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .extract().response();
+        
+        Long participantId = joinResponse.jsonPath().getLong("id");
+        
+        // When & Then: 인증 토큰 없이 강퇴 시도
+        given()
+                .pathParam("meetupId", meetup.id())
+                .pathParam("participantId", participantId)
+        .when()
+                .delete("/{meetupId}/participants/{participantId}")
+        .then()
+                .log().all()
+                .statusCode(401); // Unauthorized
+    }
+
+    @Test
+    @DisplayName("새 호스트 강퇴 권한 확인 - 204 No Content")
+    void kickParticipant_newHostCanKick_success() {
+        // Given: 밋업 생성 및 사용자들 참가
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        // 두 사용자가 밋업에 참가
+        Response joinResponse1 = given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .extract().response();
+        
+        Response joinResponse2 = given()
+                .header("Authorization", "Bearer " + tokens.get(2).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .extract().response();
+        
+        Long participantId1 = joinResponse1.jsonPath().getLong("id");
+        Long participantId2 = joinResponse2.jsonPath().getLong("id");
+        
+        // 첫 번째 사용자에게 호스트 역할 부여
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", meetup.id())
+                .pathParam("participantId", participantId1)
+        .when()
+                .patch("/{meetupId}/participants/{participantId}/grant")
+        .then()
+                .log().all()
+                .statusCode(200);
+        
+        // When & Then: 새로 호스트가 된 사용자가 다른 참가자를 강퇴
+        given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+                .pathParam("participantId", participantId2)
+        .when()
+                .delete("/{meetupId}/participants/{participantId}")
+        .then()
+                .log().all()
+                .statusCode(204);
+        
+        // 강퇴된 참가자가 목록에서 제거되었는지 확인
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .get("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .body("size()", equalTo(2)) // 원래 호스트 + 새 호스트
+                .body("profile.nickname", not(hasItem(profiles.get(2).getNickname())));
+    }
+
+    @Test
+    @DisplayName("강퇴된 참가자 재참가 가능 - 200 OK")
+    void kickParticipant_rejoinAfterKick_success() {
+        // Given: 밋업 생성, 사용자 참가 및 강퇴
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        Response joinResponse = given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .extract().response();
+        
+        Long participantId = joinResponse.jsonPath().getLong("id");
+        
+        // 참가자 강퇴
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", meetup.id())
+                .pathParam("participantId", participantId)
+        .when()
+                .delete("/{meetupId}/participants/{participantId}")
+        .then()
+                .log().all()
+                .statusCode(204);
+        
+        // When & Then: 강퇴된 사용자가 다시 참가
+        given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .body("profile.nickname", equalTo(profiles.get(1).getNickname()))
+                .body("role", equalTo("MEMBER"));
+    }
+
+    @Test
+    @DisplayName("다른 밋업 참가자 강퇴 실패 - 404 Not Found")
+    void kickParticipant_differentMeetup_fail() {
+        // Given: 두 개의 밋업 생성
+        MeetupDetail meetup1 = createTestMeetup(0);
+        MeetupDetail meetup2 = createTestMeetup(1);
+        
+        // 사용자가 두 번째 밋업에만 참가
+        Response joinResponse = given()
+                .header("Authorization", "Bearer " + tokens.get(2).accessToken())
+                .pathParam("meetupId", meetup2.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .extract().response();
+        
+        Long participantId = joinResponse.jsonPath().getLong("id");
+        
+        // When & Then: 첫 번째 밋업의 호스트가 두 번째 밋업의 참가자를 강퇴 시도
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", meetup1.id())
+                .pathParam("participantId", participantId)
+        .when()
+                .delete("/{meetupId}/participants/{participantId}")
+        .then()
+                .log().all()
+                .statusCode(404); // Not Found - 해당 밋업의 참가자가 아님
+    }
+}

--- a/src/test/java/com/pnu/momeet/e2e/participant/ParticipantLeaveTest.java
+++ b/src/test/java/com/pnu/momeet/e2e/participant/ParticipantLeaveTest.java
@@ -1,0 +1,245 @@
+package com.pnu.momeet.e2e.participant;
+
+import com.pnu.momeet.domain.meetup.dto.response.MeetupDetail;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@Tag("participant")
+@DisplayName("E2E : 밋업 나가기 테스트")
+public class ParticipantLeaveTest extends BaseParticipantTest {
+
+
+    @Test
+    @DisplayName("일반 참가자 밋업 나가기 성공 - 204 No Content")
+    void leaveMeetup_regularParticipant_success() {
+        // Given: 밋업 생성 및 사용자 참가
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        // 사용자가 밋업에 참가
+        given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200);
+        
+        // When & Then: 밋업 나가기
+        given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .delete("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(204); // No Content
+        
+        // 참가자 목록에서 제거되었는지 확인
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .get("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .body("size()", equalTo(1)) // 호스트만 남음
+                .body("[0].profile.nickname", equalTo(profiles.get(0).getNickname()));
+    }
+
+    @Test
+    @DisplayName("여러 참가자 중 일부 나가기 성공 - 204 No Content")
+    void leaveMeetup_partialLeave_success() {
+        // Given: 밋업 생성 및 여러 사용자 참가
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        // 여러 사용자가 밋업에 참가
+        for (int i = 1; i < 4; i++) {
+            given()
+                    .header("Authorization", "Bearer " + tokens.get(i).accessToken())
+                    .pathParam("meetupId", meetup.id())
+            .when()
+                    .post("/{meetupId}/participants")
+            .then()
+                    .statusCode(200);
+        }
+        
+        // When: 한 명이 밋업을 나감
+        given()
+                .header("Authorization", "Bearer " + tokens.get(2).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .delete("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(204);
+        
+        // Then: 참가자 목록 확인 (호스트 + 2명 남음)
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .get("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .body("size()", equalTo(3))
+                .body("profile.nickname", hasItems(
+                        profiles.get(0).getNickname(),
+                        profiles.get(1).getNickname(),
+                        profiles.get(3).getNickname()
+                ))
+                .body("profile.nickname", not(hasItem(profiles.get(2).getNickname())));
+    }
+
+    @Test
+    @DisplayName("참가하지 않은 밋업 나가기 실패 - 404 Not Found")
+    void leaveMeetup_notParticipant_fail() {
+        // Given: 밋업 생성 (사용자는 참가하지 않음)
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        // When & Then: 참가하지 않은 사용자가 나가기 시도
+        given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .delete("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(404); // Not Found 또는 409 Conflict
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 밋업 나가기 실패 - 404 Not Found")
+    void leaveMeetup_nonExistentMeetup_fail() {
+        // Given: 존재하지 않는 밋업 ID
+        String nonExistentMeetupId = "00000000-0000-0000-0000-000000000000";
+        
+        // When & Then: 존재하지 않는 밋업에서 나가기 시도
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", nonExistentMeetupId)
+        .when()
+                .delete("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(404); // Not Found
+    }
+
+    @Test
+    @DisplayName("미인증 사용자 밋업 나가기 실패 - 401 Unauthorized")
+    void leaveMeetup_unauthenticated_fail() {
+        // Given: 밋업 생성
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        // When & Then: 인증 토큰 없이 나가기 시도
+        given()
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .delete("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(401); // Unauthorized
+    }
+
+    @Test
+    @DisplayName("밋업 호스트 나가기 실패 - 400 Bad Request")
+    void leaveMeetup_host_fail() {
+        // Given: 밋업 생성 (호스트)
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        // When & Then: 호스트가 자신의 밋업에서 나가기 시도
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .delete("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(400); // Bad Request - 호스트는 나갈 수 없음
+    }
+
+    @Test
+    @DisplayName("밋업 나간 후 재참가 성공 - 200 OK")
+    void leaveMeetup_rejoinAfterLeave_success() {
+        // Given: 밋업 생성 및 사용자 참가
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200);
+        
+        // When: 밋업 나가기
+        given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .delete("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(204);
+        
+        // Then: 다시 참가 가능
+        given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .body("profile.nickname", equalTo(profiles.get(1).getNickname()))
+                .body("role", equalTo("MEMBER"));
+    }
+
+    @Test
+    @DisplayName("동시 여러 사용자 나가기 성공 - 204 No Content")
+    void leaveMeetup_multipleUsers_success() {
+        // Given: 밋업 생성 및 여러 사용자 참가
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        for (int i = 1; i < TEST_USER_COUNT; i++) {
+            given()
+                    .header("Authorization", "Bearer " + tokens.get(i).accessToken())
+                    .pathParam("meetupId", meetup.id())
+            .when()
+                    .post("/{meetupId}/participants")
+            .then()
+                    .statusCode(200);
+        }
+        
+        // When: 여러 사용자가 밋업을 나감 (호스트 제외)
+        for (int i = 1; i < TEST_USER_COUNT; i++) {
+            given()
+                    .header("Authorization", "Bearer " + tokens.get(i).accessToken())
+                    .pathParam("meetupId", meetup.id())
+            .when()
+                    .delete("/{meetupId}/participants")
+            .then()
+                    .statusCode(204);
+        }
+        
+        // Then: 호스트만 남아있는지 확인
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .get("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .body("size()", equalTo(1))
+                .body("[0].profile.nickname", equalTo(profiles.get(0).getNickname()))
+                .body("[0].role", equalTo("HOST"));
+    }
+}

--- a/src/test/java/com/pnu/momeet/e2e/participant/ParticipantListTest.java
+++ b/src/test/java/com/pnu/momeet/e2e/participant/ParticipantListTest.java
@@ -1,0 +1,194 @@
+package com.pnu.momeet.e2e.participant;
+
+import com.pnu.momeet.domain.meetup.dto.response.MeetupDetail;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@Tag("participant")
+@DisplayName("E2E : 참가자 목록 조회 테스트")
+public class ParticipantListTest extends BaseParticipantTest {
+
+
+    @Test
+    @DisplayName("참가자 목록 조회 성공 - 200 OK")
+    void getParticipantsList_success() {
+        // Given: 밋업 생성 및 여러 사용자 참가
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        // 다른 사용자들을 밋업에 참가시킴
+        for (int i = 1; i < 3; i++) {
+            given()
+                    .header("Authorization", "Bearer " + tokens.get(i).accessToken())
+                    .pathParam("meetupId", meetup.id())
+            .when()
+                    .post("/{meetupId}/participants")
+            .then()
+                    .statusCode(200);
+        }
+        
+        // When & Then: 참가자 목록 조회
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .get("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .body("size()", equalTo(3)) // 호스트 + 참가자 2명
+                .body("profile.nickname", hasItems(
+                        profiles.get(0).getNickname(),
+                        profiles.get(1).getNickname(),
+                        profiles.get(2).getNickname()
+                ))
+                .body("find { it.role == 'HOST' }.profile.nickname", equalTo(profiles.get(0).getNickname()))
+                .body("findAll { it.role == 'MEMBER' }.size()", equalTo(2));
+    }
+
+    @Test
+    @DisplayName("빈 참가자 목록 조회 성공 - 200 OK")
+    void getParticipantsList_emptyList_success() {
+        // Given: 밋업 생성 (호스트만 있음)
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        // When & Then: 참가자 목록 조회
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .get("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .body("size()", equalTo(1)) // 호스트만
+                .body("[0].profile.nickname", equalTo(profiles.get(0).getNickname()))
+                .body("[0].role", equalTo("HOST"));
+    }
+
+    @Test
+    @DisplayName("일반 참가자 목록 조회 성공 - 200 OK")
+    void getParticipantsList_regularParticipant_success() {
+        // Given: 밋업 생성 및 사용자 참가
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200);
+        
+        // When & Then: 일반 참가자가 목록 조회
+        given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .get("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .body("size()", equalTo(2));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 밋업 참가자 목록 조회 실패 - 404 Not Found")
+    void getParticipantsList_nonExistentMeetup_fail() {
+        // Given: 존재하지 않는 밋업 ID
+        String nonExistentMeetupId = "00000000-0000-0000-0000-000000000000";
+        
+        // When & Then: 존재하지 않는 밋업의 참가자 목록 조회
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", nonExistentMeetupId)
+        .when()
+                .get("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(404); // Not Found
+    }
+
+    @Test
+    @DisplayName("미인증 사용자 참가자 목록 조회 실패 - 401 Unauthorized")
+    void getParticipantsList_unauthenticated_fail() {
+        // Given: 밋업 생성
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        // When & Then: 인증 토큰 없이 목록 조회
+        given()
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .get("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(401); // Unauthorized
+    }
+
+    @Test
+    @DisplayName("참가자 프로필 정보 포함 확인 - 200 OK")
+    void getParticipantsList_profileInfoIncluded_success() {
+        // Given: 밋업 생성 및 사용자 참가
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200);
+        
+        // When & Then: 참가자 목록 조회 시 프로필 정보 확인
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .get("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .body("size()", equalTo(2))
+                .body("[0].profile", notNullValue())
+                .body("[0].profile.nickname", notNullValue())
+                .body("[0].profile.age", notNullValue())
+                .body("[0].profile.gender", notNullValue())
+                .body("[0].createdAt", notNullValue())
+                .body("[0].isRated", notNullValue());
+    }
+
+    @Test
+    @DisplayName("다수 참가자 목록 조회 성공 - 200 OK")
+    void getParticipantsList_multipleParticipants_success() {
+        // Given: 밋업 생성 및 모든 테스트 사용자 참가
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        for (int i = 1; i < TEST_USER_COUNT; i++) {
+            given()
+                    .header("Authorization", "Bearer " + tokens.get(i).accessToken())
+                    .pathParam("meetupId", meetup.id())
+            .when()
+                    .post("/{meetupId}/participants")
+            .then()
+                    .statusCode(200);
+        }
+        
+        // When & Then: 전체 참가자 목록 조회
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .get("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .body("size()", equalTo(TEST_USER_COUNT))
+                .body("findAll { it.role == 'HOST' }.size()", equalTo(1))
+                .body("findAll { it.role == 'MEMBER' }.size()", equalTo(TEST_USER_COUNT - 1));
+    }
+}

--- a/src/test/java/com/pnu/momeet/e2e/participant/ParticipantRoleTest.java
+++ b/src/test/java/com/pnu/momeet/e2e/participant/ParticipantRoleTest.java
@@ -1,0 +1,256 @@
+package com.pnu.momeet.e2e.participant;
+
+import com.pnu.momeet.domain.meetup.dto.response.MeetupDetail;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@Tag("participant")
+@DisplayName("E2E : 참가자 역할 권한 부여 테스트")
+public class ParticipantRoleTest extends BaseParticipantTest {
+
+
+    @Test
+    @DisplayName("호스트 역할 부여 성공 - 200 OK")
+    void grantHostRole_success() {
+        // Given: 밋업 생성 및 사용자 참가
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        // 사용자가 밋업에 참가
+        Response joinResponse = given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .extract().response();
+        
+        Long participantId = joinResponse.jsonPath().getLong("id");
+        
+        // When & Then: 호스트가 참가자에게 호스트 역할 부여
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", meetup.id())
+                .pathParam("participantId", participantId)
+        .when()
+                .patch("/{meetupId}/participants/{participantId}/grant")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .body("role", equalTo("HOST"))
+                .body("profile.nickname", equalTo(profiles.get(1).getNickname()));
+        
+        // 참가자 목록에서 역할 변경 확인
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .get("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .body("findAll { it.role == 'HOST' }.size()", equalTo(1)) // HOST는 1명만 존재
+                .body("find { it.profile.nickname == '" + profiles.get(1).getNickname() + "' }.role", equalTo("HOST")) // 새로운 HOST
+                .body("find { it.profile.nickname == '" + profiles.get(0).getNickname() + "' }.role", equalTo("MEMBER")); // 기존 HOST는 MEMBER로 변경
+    }
+
+    @Test
+    @DisplayName("일반 참가자 역할 부여 실패 - 403 Forbidden")
+    void grantHostRole_regularParticipant_fail() {
+        // Given: 밋업 생성 및 여러 사용자 참가
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        // 두 사용자가 밋업에 참가
+        given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200);
+        
+        Response joinResponse = given()
+                .header("Authorization", "Bearer " + tokens.get(2).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .extract().response();
+        
+        Long participantId = joinResponse.jsonPath().getLong("id");
+        
+        // When & Then: 일반 참가자가 다른 참가자에게 역할 부여 시도
+        given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+                .pathParam("participantId", participantId)
+        .when()
+                .patch("/{meetupId}/participants/{participantId}/grant")
+        .then()
+                .log().all()
+                .statusCode(403); // Forbidden - 권한 없음
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 참가자 역할 부여 실패 - 404 Not Found")
+    void grantHostRole_nonExistentParticipant_fail() {
+        // Given: 밋업 생성
+        MeetupDetail meetup = createTestMeetup(0);
+        Long nonExistentParticipantId = 99999L;
+        
+        // When & Then: 존재하지 않는 참가자에게 역할 부여 시도
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", meetup.id())
+                .pathParam("participantId", nonExistentParticipantId)
+        .when()
+                .patch("/{meetupId}/participants/{participantId}/grant")
+        .then()
+                .log().all()
+                .statusCode(404); // Not Found
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 밋업 역할 부여 실패 - 404 Not Found")
+    void grantHostRole_nonExistentMeetup_fail() {
+        // Given: 존재하지 않는 밋업 ID
+        String nonExistentMeetupId = "00000000-0000-0000-0000-000000000000";
+        Long participantId = 1L;
+        
+        // When & Then: 존재하지 않는 밋업에서 역할 부여 시도
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", nonExistentMeetupId)
+                .pathParam("participantId", participantId)
+        .when()
+                .patch("/{meetupId}/participants/{participantId}/grant")
+        .then()
+                .log().all()
+                .statusCode(404); // Not Found
+    }
+
+    @Test
+    @DisplayName("미인증 사용자 역할 부여 실패 - 401 Unauthorized")
+    void grantHostRole_unauthenticated_fail() {
+        // Given: 밋업 생성 및 사용자 참가
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        Response joinResponse = given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .extract().response();
+        
+        Long participantId = joinResponse.jsonPath().getLong("id");
+        
+        // When & Then: 인증 토큰 없이 역할 부여 시도
+        given()
+                .pathParam("meetupId", meetup.id())
+                .pathParam("participantId", participantId)
+        .when()
+                .patch("/{meetupId}/participants/{participantId}/grant")
+        .then()
+                .log().all()
+                .statusCode(401); // Unauthorized
+    }
+
+    @Test
+    @DisplayName("다른 밋업 참가자 역할 부여 실패 - 404 Not Found")
+    void grantHostRole_differentMeetupParticipant_fail() {
+        // Given: 두 개의 밋업 생성
+        MeetupDetail meetup1 = createTestMeetup(0);
+        MeetupDetail meetup2 = createTestMeetup(1);
+        
+        // 사용자가 두 번째 밋업에만 참가
+        Response joinResponse = given()
+                .header("Authorization", "Bearer " + tokens.get(2).accessToken())
+                .pathParam("meetupId", meetup2.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .extract().response();
+        
+        Long participantId = joinResponse.jsonPath().getLong("id");
+        
+        // When & Then: 첫 번째 밋업의 호스트가 두 번째 밋업의 참가자에게 역할 부여 시도
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", meetup1.id())
+                .pathParam("participantId", participantId)
+        .when()
+                .patch("/{meetupId}/participants/{participantId}/grant")
+        .then()
+                .log().all()
+                .statusCode(404); // Not Found - 해당 밋업의 참가자가 아님
+    }
+
+    @Test
+    @DisplayName("새 호스트 역할 부여 권한 확인 - 200 OK")
+    void grantHostRole_newHostCanGrant_success() {
+        // Given: 밋업 생성 및 사용자들 참가
+        MeetupDetail meetup = createTestMeetup(0);
+        
+        // 두 사용자가 밋업에 참가
+        Response joinResponse1 = given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .extract().response();
+        
+        Response joinResponse2 = given()
+                .header("Authorization", "Bearer " + tokens.get(2).accessToken())
+                .pathParam("meetupId", meetup.id())
+        .when()
+                .post("/{meetupId}/participants")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .extract().response();
+        
+        Long participantId1 = joinResponse1.jsonPath().getLong("id");
+        Long participantId2 = joinResponse2.jsonPath().getLong("id");
+        
+        // 첫 번째 사용자에게 호스트 역할 부여
+        given()
+                .header("Authorization", "Bearer " + tokens.get(0).accessToken())
+                .pathParam("meetupId", meetup.id())
+                .pathParam("participantId", participantId1)
+        .when()
+                .patch("/{meetupId}/participants/{participantId}/grant")
+        .then()
+                .log().all()
+                .statusCode(200);
+        
+        // When & Then: 새로 호스트가 된 사용자가 다른 참가자에게 역할 부여
+        given()
+                .header("Authorization", "Bearer " + tokens.get(1).accessToken())
+                .pathParam("meetupId", meetup.id())
+                .pathParam("participantId", participantId2)
+        .when()
+                .patch("/{meetupId}/participants/{participantId}/grant")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .body("role", equalTo("HOST"))
+                .body("profile.nickname", equalTo(profiles.get(2).getNickname()));
+    }
+}

--- a/src/test/resources/sql/test_init_data.sql
+++ b/src/test/resources/sql/test_init_data.sql
@@ -11,6 +11,19 @@ VALUES (
     'ROLE_ADMIN'
 );
 
+-- Admin용 프로필 생성
+INSERT INTO public_test.profile (
+    member_id, nickname, age, gender, image_url, description, base_location
+) VALUES (
+    (SELECT id FROM public_test.member WHERE email = 'admin@test.com'),
+    '관리자',
+    30,
+    'MALE',
+    'https://cdn.example.com/profiles/admin.png',
+    '테스트 환경용 관리자 프로필',
+    '부산 해운대구'
+);
+
 -- password: testpass1212!
 INSERT INTO public_test.member (email, password)
 VALUES (

--- a/src/test/resources/sql/test_init_scheme.sql
+++ b/src/test/resources/sql/test_init_scheme.sql
@@ -1,5 +1,6 @@
 CREATE SCHEMA IF NOT EXISTS public_test;
 
+DROP TABLE IF EXISTS meetup_participant CASCADE;
 DROP TABLE IF EXISTS public_test.meetup_hash_tag CASCADE;
 DROP TABLE IF EXISTS public_test.meetup CASCADE;
 DROP TABLE IF EXISTS public_test.refresh_token CASCADE;
@@ -69,6 +70,7 @@ CREATE TABLE public_test.meetup (
     category        VARCHAR(30) NOT NULL,
     sub_category    VARCHAR(30) NOT NULL,
     description     TEXT        NOT NULL,
+    participant_count INTEGER     NOT NULL DEFAULT 1,
     capacity        INTEGER     NOT NULL DEFAULT 10,
     score_limit     DOUBLE PRECISION NOT NULL DEFAULT 36.5,
     location_point  geography(Point, 4326) NOT NULL,
@@ -92,3 +94,17 @@ CREATE TABLE public_test.meetup_hash_tag (
     name            VARCHAR(100) NOT NULL,
     created_at      TIMESTAMP   NOT NULL DEFAULT NOW()
 );
+
+CREATE TABLE meetup_participant (
+                                    id              BIGSERIAL PRIMARY KEY,
+                                    meetup_id       UUID NOT NULL REFERENCES meetup(id) ON DELETE CASCADE,
+                                    profile_id      UUID NOT NULL REFERENCES profile(id) ON DELETE CASCADE,
+                                    role            VARCHAR(20) NOT NULL DEFAULT 'MEMBER',
+                                    is_rated        BOOLEAN NOT NULL DEFAULT FALSE,
+                                    last_active_at  TIMESTAMP,
+                                    created_at      TIMESTAMP   NOT NULL DEFAULT NOW(),
+                                    UNIQUE(meetup_id, profile_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_meetup_participant_meetup ON meetup_participant (meetup_id);
+CREATE INDEX IF NOT EXISTS idx_meetup_participant_profile ON meetup_participant (profile_id);

--- a/src/test/resources/sql/test_init_scheme.sql
+++ b/src/test/resources/sql/test_init_scheme.sql
@@ -1,6 +1,7 @@
 CREATE SCHEMA IF NOT EXISTS public_test;
 
-DROP TABLE IF EXISTS meetup_participant CASCADE;
+-- 외래키 의존성 순서대로 DROP
+DROP TABLE IF EXISTS public_test.meetup_participant CASCADE;
 DROP TABLE IF EXISTS public_test.meetup_hash_tag CASCADE;
 DROP TABLE IF EXISTS public_test.meetup CASCADE;
 DROP TABLE IF EXISTS public_test.refresh_token CASCADE;
@@ -95,16 +96,16 @@ CREATE TABLE public_test.meetup_hash_tag (
     created_at      TIMESTAMP   NOT NULL DEFAULT NOW()
 );
 
-CREATE TABLE meetup_participant (
-                                    id              BIGSERIAL PRIMARY KEY,
-                                    meetup_id       UUID NOT NULL REFERENCES meetup(id) ON DELETE CASCADE,
-                                    profile_id      UUID NOT NULL REFERENCES profile(id) ON DELETE CASCADE,
-                                    role            VARCHAR(20) NOT NULL DEFAULT 'MEMBER',
-                                    is_rated        BOOLEAN NOT NULL DEFAULT FALSE,
-                                    last_active_at  TIMESTAMP,
-                                    created_at      TIMESTAMP   NOT NULL DEFAULT NOW(),
-                                    UNIQUE(meetup_id, profile_id)
+CREATE TABLE public_test.meetup_participant (
+    id              BIGSERIAL PRIMARY KEY,
+    meetup_id       UUID NOT NULL REFERENCES public_test.meetup(id) ON DELETE CASCADE,
+    profile_id      UUID NOT NULL REFERENCES public_test.profile(id) ON DELETE CASCADE,
+    role            VARCHAR(20) NOT NULL DEFAULT 'MEMBER',
+    is_rated        BOOLEAN NOT NULL DEFAULT FALSE,
+    last_active_at  TIMESTAMP,
+    created_at      TIMESTAMP   NOT NULL DEFAULT NOW(),
+    UNIQUE(meetup_id, profile_id)
 );
 
-CREATE INDEX IF NOT EXISTS idx_meetup_participant_meetup ON meetup_participant (meetup_id);
-CREATE INDEX IF NOT EXISTS idx_meetup_participant_profile ON meetup_participant (profile_id);
+CREATE INDEX IF NOT EXISTS idx_meetup_participant_meetup ON public_test.meetup_participant (meetup_id);
+CREATE INDEX IF NOT EXISTS idx_meetup_participant_profile ON public_test.meetup_participant (profile_id);

--- a/src/test/resources/sql/test_init_scheme.sql
+++ b/src/test/resources/sql/test_init_scheme.sql
@@ -101,11 +101,13 @@ CREATE TABLE public_test.meetup_participant (
     meetup_id       UUID NOT NULL REFERENCES public_test.meetup(id) ON DELETE CASCADE,
     profile_id      UUID NOT NULL REFERENCES public_test.profile(id) ON DELETE CASCADE,
     role            VARCHAR(20) NOT NULL DEFAULT 'MEMBER',
+    is_active       BOOLEAN NOT NULL DEFAULT FALSE,
     is_rated        BOOLEAN NOT NULL DEFAULT FALSE,
     last_active_at  TIMESTAMP,
     created_at      TIMESTAMP   NOT NULL DEFAULT NOW(),
     UNIQUE(meetup_id, profile_id)
 );
+
 
 CREATE INDEX IF NOT EXISTS idx_meetup_participant_meetup ON public_test.meetup_participant (meetup_id);
 CREATE INDEX IF NOT EXISTS idx_meetup_participant_profile ON public_test.meetup_participant (profile_id);


### PR DESCRIPTION
##🔗 관련 이슈
Closes #37 28 (Participant 도메인 E2E 테스트 작성)

##💡 변경 이유

Participant 도메인의 E2E 테스트를 구현하면서 Meetup 도메인과의 연관관계에서 발생하는 여러 문제점들을 발견하고 해결했습니다. 
특히 Meetup 생성 시 호스트가 자동으로 Participant로 등록되지 않는 문제와 데이터 정합성 문제들을 해결하기 위해 도메인 간 연관관계를 개선했습니다.

## 📋 주요 변경사항

+ Participant 도메인 E2E 테스트 구현: Join, List, Leave, Role, Kick 기능의 완전한 테스트 커버리지 구현
+ Meetup 도메인 개선: 호스트 자동 참가 로직 구현 및 Participant와의 연관관계 개선
+ MeetupService 수정: createMeetup 시 호스트가 자동으로 HOST 역할의 Participant로 등록되도록 개선
+ ParticipantService 구현: 밋업 참가/탈퇴, 역할 관리, 강퇴 기능의 비즈니스 로직 구현
+ 데이터베이스 스키마 개선: 외래키 제약조건 및 Cascade 설정 최적화
+ 비정규화 필드 추가: Meetup 엔티티에 participantCount 필드 추가로 성능 최적화
+ QueryDSL 도입: 복잡한 조회 쿼리 성능 개선
+ 테스트 인프라 개선: BaseParticipantTest 구현으로 테스트 코드 재사용성 향상

## ⚠️ 발견된 위험이나 장애

+  외래키 제약조건: Meetup의 owner_id가 Profile을 참조하므로 삭제 순서 주의 필요 (Meetup → Profile → Member 순)
+ 동시성 문제: ParticipantCount 업데이트 시 Race Condition 가능성 (추후 개선 필요)
+ QueryDSL 의존성: QueryDSL 도입으로 인해 Q클래스 생성이 필요하므로 ./gradlew clean build -x test 실행 필요

## 👀 리뷰 포인트

+ MeetupService.createMeetup(): 호스트 자동 참가 로직이 올바르게 구현되었는지 확인
+ ParticipantService: 비즈니스 규칙(정원 확인, 권한 검증 등)이 적절히 구현되었는지 검토
+ E2E 테스트: 각 테스트 시나리오가 실제 비즈니스 요구사항을 올바르게 검증하는지 확인
+ 데이터베이스 연관관계: Meetup-Participant 간 양방향 연관관계가 올바르게 설정되었는지 점검
+ HTTP 상태코드: 인증(401) vs 권한(403) 구분이 적절한지 확인
## ✅ 테스트 완료 사항

- [X] 로컬에서 정상 동작 확인
- [X] 기존 Meetup 기능에 영향 없음 확인
- [X]  Participant 도메인 전체 E2E 테스트 통과
- [X]  호스트 자동 참가 기능 테스트 완료
- [X]  역할 권한 부여/강퇴 기능 테스트 완료
- [X]  데이터베이스 제약조건 및 Cascade 동작 검증
- [X]  인증/권한 관련 HTTP 상태코드 검증
- [X]  테스트 데이터 정리 로직 안정성 확인# Pull Request 템플릿