### PR TITLE
Refactor/85 block report

### DIFF
--- a/src/main/java/com/pnu/momeet/common/advice/GlobalRestExceptionHandler.java
+++ b/src/main/java/com/pnu/momeet/common/advice/GlobalRestExceptionHandler.java
@@ -173,7 +173,7 @@ public class GlobalRestExceptionHandler {
         if (constraint != null && constraint.equalsIgnoreCase(UNIQUE_BLOCK)) {
             ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, "이미 차단한 사용자입니다.");
             problemDetail.setTitle("데이터 무결성 오류");
-            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(problemDetail);
         }
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "데이터 무결성 제약을 위반했습니다.");
         problemDetail.setTitle("데이터 무결성 오류");

--- a/src/main/java/com/pnu/momeet/common/advice/GlobalRestExceptionHandler.java
+++ b/src/main/java/com/pnu/momeet/common/advice/GlobalRestExceptionHandler.java
@@ -1,6 +1,9 @@
 package com.pnu.momeet.common.advice;
 
 import com.pnu.momeet.common.exception.*;
+import jakarta.servlet.http.HttpServletRequest;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
@@ -16,6 +19,8 @@ import java.util.*;
 
 @RestControllerAdvice
 public class GlobalRestExceptionHandler {
+
+    private static final String UNIQUE_BLOCK = "uq_user_block";
 
     private Map<String, List<String>> extractValidationErrors(MethodArgumentNotValidException e) {
         // 필드 에러 처리
@@ -161,4 +166,17 @@ public class GlobalRestExceptionHandler {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(problemDetail);
     }
 
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ProblemDetail> handleDataIntegrityViolationException(DataIntegrityViolationException e) {
+        String constraint = (e.getCause() instanceof ConstraintViolationException cve)
+            ? cve.getConstraintName() : null;
+        if (constraint != null && constraint.equalsIgnoreCase(UNIQUE_BLOCK)) {
+            ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, "이미 차단한 사용자입니다.");
+            problemDetail.setTitle("데이터 무결성 오류");
+            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+        }
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "데이터 무결성 제약을 위반했습니다.");
+        problemDetail.setTitle("데이터 무결성 오류");
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problemDetail);
+    }
 }

--- a/src/main/java/com/pnu/momeet/domain/block/service/BlockDomainService.java
+++ b/src/main/java/com/pnu/momeet/domain/block/service/BlockDomainService.java
@@ -59,14 +59,9 @@ public class BlockDomainService {
             throw new IllegalStateException("이미 차단한 사용자입니다.");
         }
 
-        try {
-            UserBlock block = entityService.save(me, targetId);
-            log.info("차단 완료. blockerId={}, blockedId={}", me, targetId);
-            return BlockEntityMapper.toBlockResponse(block);
-        } catch (DataIntegrityViolationException e) {
-            log.info("경쟁 상태 중복 차단. blockerId={}, blockedId={}", me, targetId);
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 차단한 사용자입니다.");
-        }
+        UserBlock block = entityService.save(me, targetId);
+        log.info("차단 완료. blockerId={}, blockedId={}", me, targetId);
+        return BlockEntityMapper.toBlockResponse(block);
     }
 
     @Transactional

--- a/src/main/java/com/pnu/momeet/domain/report/entity/UserReport.java
+++ b/src/main/java/com/pnu/momeet/domain/report/entity/UserReport.java
@@ -67,10 +67,10 @@ public class UserReport extends BaseEntity {
         return entity;
     }
 
-    public void processReport(UUID adminProfileId, String reply) {
+    public void processReport(UUID adminMemberId, String reply) {
         this.status = ReportStatus.ENDED;
         this.adminReply = (reply == null || reply.isBlank()) ? null : reply.strip();
-        this.processedBy = adminProfileId;
+        this.processedBy = adminMemberId;
         this.processedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/pnu/momeet/domain/report/service/ReportDomainService.java
+++ b/src/main/java/com/pnu/momeet/domain/report/service/ReportDomainService.java
@@ -172,16 +172,15 @@ public class ReportDomainService {
 
     @Transactional
     public ReportDetailResponse processReport(UUID memberId, UUID reportId, ReportProcessRequest request) {
-        Profile adminProfile = profileService.getByMemberId(memberId);
         UserReport report = entityService.getById(reportId);
         if (report.getStatus() != ReportStatus.OPEN) {
             log.info("OPEN 상태가 아닌 신고 처리 시도. reportId={}", reportId);
             throw new IllegalStateException("OPEN 상태의 신고가 아닙니다.");
         }
         String reply = (request == null) ? null : request.reply();
-        entityService.processReport(report, adminProfile.getId(), reply);
+        entityService.processReport(report, memberId, reply);
         List<String> urls = entityService.getAttachmentUrls(reportId);
-        log.info("신고 처리 성공. reportId={}, adminProfileId={}", reportId, adminProfile.getId());
+        log.info("신고 처리 성공. reportId={}, adminMemberId={}", reportId, memberId);
         return ReportEntityMapper.toReportDetailResponse(report, urls);
     }
 }

--- a/src/main/java/com/pnu/momeet/domain/report/service/ReportDomainService.java
+++ b/src/main/java/com/pnu/momeet/domain/report/service/ReportDomainService.java
@@ -112,16 +112,17 @@ public class ReportDomainService {
         entityService.save(report);
 
         List<String> uploadedUrls = new ArrayList<>();
+        List<ReportAttachment> attachments = new ArrayList<>();
         try {
             List<MultipartFile> images = request.images();
             if (images != null && !images.isEmpty()) {
                 for (MultipartFile image : images) {
                     String prefix = REPORT_IMAGE_PREFIX + "/" + report.getId();
                     String url = s3StorageService.uploadImage(image, prefix);
-                    ReportAttachment attachment = ReportDtoMapper.toAttachment(report.getId(), url);
-                    entityService.save(attachment);
                     uploadedUrls.add(url);
+                    attachments.add(ReportDtoMapper.toAttachment(report.getId(), url));
                 }
+                entityService.saveAll(attachments);
             }
         } catch (Exception e) {     // S3 업로드 실패 시 지금까지 업로드 된 이미지 제거
             for (int i = uploadedUrls.size() - 1; i >= 0; i--) {

--- a/src/main/java/com/pnu/momeet/domain/report/service/ReportEntityService.java
+++ b/src/main/java/com/pnu/momeet/domain/report/service/ReportEntityService.java
@@ -125,20 +125,15 @@ public class ReportEntityService {
         return saved;
     }
 
-    @Transactional
-    public ReportAttachment save(ReportAttachment attachment) {
-        log.debug("신고 첨부파일 저장 시도. id={}, reportId={}, url={}",
-            attachment.getId(),
-            attachment.getReportId(),
-            attachment.getUrl()
-        );
-        ReportAttachment saved = reportAttachmentRepository.save(attachment);
-        log.debug("신고 첨부파일 저장 성공. id={}, reportId={}, url={}",
-            attachment.getId(),
-            attachment.getReportId(),
-            attachment.getUrl()
-        );
-        return saved;
+    public void saveAll(List<ReportAttachment> attachments) {
+        List<ReportAttachment> saved = reportAttachmentRepository.saveAll(attachments);
+        if (log.isDebugEnabled()) {
+            saved.forEach(a ->
+                log.debug("신고 첨부파일 저장 성공. id={}, reportId={}, url={}",
+                    a.getId(), a.getReportId(), a.getUrl()
+                )
+            );
+        }
     }
 
     @Transactional

--- a/src/main/java/com/pnu/momeet/domain/report/service/ReportEntityService.java
+++ b/src/main/java/com/pnu/momeet/domain/report/service/ReportEntityService.java
@@ -144,10 +144,10 @@ public class ReportEntityService {
     }
 
     @Transactional
-    public void processReport(UserReport report, UUID adminProifleId, String reply) {
-        log.debug("신고 처리 시도. reportId={}, adminProfileId={}", report.getId(), adminProifleId);
-        report.processReport(adminProifleId, reply);
+    public void processReport(UserReport report, UUID adminMemberId, String reply) {
+        log.debug("신고 처리 시도. reportId={}, adminMemberId={}", report.getId(), adminMemberId);
+        report.processReport(adminMemberId, reply);
         reportRepository.save(report);
-        log.debug("신고 처리 성공. reportId={}, adminProfileId={}", report.getId(), adminProifleId);
+        log.debug("신고 처리 성공. reportId={}, adminMemberId={}", report.getId(), adminMemberId);
     }
 }

--- a/src/main/resources/sql/init_scheme.sql
+++ b/src/main/resources/sql/init_scheme.sql
@@ -214,9 +214,6 @@ CREATE TABLE IF NOT EXISTS user_block (
     CONSTRAINT ck_user_block_self CHECK (blocker_id <> blocked_id)
 );
 
-CREATE INDEX IF NOT EXISTS idx_user_block_blocker ON user_block (blocker_id);
-CREATE INDEX IF NOT EXISTS idx_user_block_blocked ON user_block (blocked_id);
-
 CREATE TABLE user_report (
     id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     reporter_profile_id  UUID NOT NULL REFERENCES profile(id) ON DELETE CASCADE,

--- a/src/test/java/com/pnu/momeet/e2e/report/BaseReportTest.java
+++ b/src/test/java/com/pnu/momeet/e2e/report/BaseReportTest.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -76,6 +77,11 @@ public class BaseReportTest extends BaseE2ETest {
             attachmentToBeDeleted.forEach(badgeId -> attachmentRepository.deleteById(badgeId));
             attachmentToBeDeleted.clear();
         }
+    }
+
+    @AfterAll
+    static void tearDownReport() {
+        RestAssured.reset();
     }
 
     protected TokenResponse getToken(Role role) {

--- a/src/test/java/com/pnu/momeet/unit/report/ReportEntityServiceTest.java
+++ b/src/test/java/com/pnu/momeet/unit/report/ReportEntityServiceTest.java
@@ -14,6 +14,7 @@ import com.pnu.momeet.domain.report.repository.ReportAttachmentRepository;
 import com.pnu.momeet.domain.report.repository.ReportRepository;
 import com.pnu.momeet.domain.report.service.ReportEntityService;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -159,13 +160,14 @@ class ReportEntityServiceTest {
     @Test
     @DisplayName("save(ReportAttachment) - 레포 위임")
     void save_attachment() {
+        List<ReportAttachment> atts = new ArrayList<>();
         ReportAttachment att = ReportAttachment.create(UUID.randomUUID(), "https://cdn/reports/x.png");
-        given(attachmentRepository.save(att)).willReturn(att);
+        atts.add(att);
+        given(attachmentRepository.saveAll(atts)).willReturn(atts);
 
-        ReportAttachment saved = entityService.save(att);
+        entityService.saveAll(atts);
 
-        assertThat(saved).isSameAs(att);
-        verify(attachmentRepository).save(att);
+        verify(attachmentRepository).saveAll(atts);
     }
 
     @Test


### PR DESCRIPTION
# Pull Request 템플릿

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 걸어주세요 -->
- Closes #(85)

## 💡 변경 이유
<!-- 왜 이 코드 변경이 필요했나요? 어떤 문제를 해결하거나 어떤 기능을 추가했나요? -->

- 7주차 코드 리뷰에서의 차단 및 신고 기능에 대한 멘토님의 피드백 반영
- 관리자의 신고 처리 API 에서 관리자의 프로필을 필요로 하지 않도록 수정

## 📋 주요 변경사항
<!-- 구체적으로 어떤 것들이 변경되었는지 간단히 나열해주세요 -->

- createUserBlock 메서드 중복 차단 관련 전역 예외 핸들링 추가 및 정리
- createReport 메서드에서 신고 이미지 S3 업로드 성공 시 첨부파일 일괄 저장으로 리팩터링
- user_block에 대한 단일 인덱스 제거
- 관리자 프로필 없이 memberId로 신고 처리 전환
- 관련 테스트 수정

## ⚠️ 발견된 위험이나 장애
<!-- 개발 중 발견된 문제점이나 주의할 부분이 있다면 작성해주세요 (없으면  삭제) -->


## 👀 리뷰 포인트
<!-- 리뷰어가 특별히 집중해서 봐야 할 부분을 알려주세요 -->
- 
- 

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 (없으면 삭제해도 됩니다) -->


## ✅ 테스트 완료 사항
<!-- 어떻게 테스트했는지 간단히 작성해주세요 -->
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer conflict response when attempting to block an already-blocked user (returns a distinct conflict message).
  * Improved handling of data integrity violations with more specific error messages.

* **Refactor**
  * Switched report attachment handling to batch saves for efficiency.
  * Standardized admin identifier usage and streamlined report processing flow.

* **Chores**
  * Removed redundant indexes for user-block relations.

* **Tests**
  * Added end-to-end teardown after all tests and updated unit tests for batch attachment handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->