### PR TITLE
Refactor/98 evaluatable user

### DIFF
--- a/src/main/resources/sql/init_data.sql
+++ b/src/main/resources/sql/init_data.sql
@@ -75,3 +75,154 @@ VALUES (
         '풋살·등산 러버 🏔️',
         26260
        );
+
+-- 테스트 모임 생성용 계정 1
+-- password: testpass1212!
+INSERT INTO member (email, password, verified)
+VALUES (
+           'meetupowner1@test.com',
+           '$2a$10$c.KAjYSgNz6KLUtG7Qw0B.i/vviGv/FgKvMH7orJFvx8Oh0.wmJ5G',
+           TRUE
+       );
+
+INSERT INTO member_role (member_id, name)
+VALUES (
+           (SELECT id FROM member WHERE email = 'meetupowner1@test.com'),
+           'ROLE_USER'
+       );
+
+INSERT INTO profile (member_id, nickname, age, gender, image_url, description, base_location_id)
+VALUES (
+    (SELECT id FROM member WHERE email = 'meetupowner1@test.com'),
+    '방장1',
+    30,
+    'MALE',
+    'https://momeet-dev-bucket-1.s3.ap-northeast-2.amazonaws.com/profiles/meetupOwner.png',
+    '방장1 테스트 프로필',
+    26260
+);
+
+-- 테스트 모임 1: 광안 농구 모임
+INSERT INTO meetup (
+    owner_id, name, category, description, participant_count, capacity, score_limit, location_point,
+    address, sgg_code, status, start_at, end_at
+)
+VALUES (
+           (SELECT id FROM profile WHERE nickname = '방장1'),
+           '광안 농구 모임',
+           'SPORTS',
+           '광안리 근처 농구장 같이 뛰실 분 구합니다! 🏀',
+           1,
+           10,
+           36.0,
+           ST_GeomFromText('POINT(129.08225 35.23103)', 4326),
+           '부산광역시 수영구 광안동 농구장',
+           26410,
+           'OPEN',
+           date_trunc('hour', now()) + interval '1 hour' + make_interval(mins => case when extract(minute from now()) >= 30 then 30 else 0 end),
+           date_trunc('hour', now()) + interval '4 hour' + make_interval(mins => case when extract(minute from now()) >= 30 then 30 else 0 end)
+       );
+
+-- 테스트 모임 생성용 계정 2
+-- password: testpass1212!
+INSERT INTO member (email, password, verified)
+VALUES (
+    'meetupowner2@test.com',
+    '$2a$10$c.KAjYSgNz6KLUtG7Qw0B.i/vviGv/FgKvMH7orJFvx8Oh0.wmJ5G',
+    TRUE
+);
+
+INSERT INTO member_role (member_id, name)
+VALUES (
+    (SELECT id FROM member WHERE email = 'meetupowner2@test.com'),
+    'ROLE_USER'
+);
+
+INSERT INTO profile (member_id, nickname, age, gender, image_url, description, base_location_id)
+VALUES (
+    (SELECT id FROM member WHERE email = 'meetupowner2@test.com'),
+    '방장2',
+    50,
+    'MALE',
+    'https://momeet-dev-bucket-1.s3.ap-northeast-2.amazonaws.com/profiles/meetupOwner2.png',
+    '방장2 테스트 프로필',
+    26260
+);
+
+-- ⚽ 테스트 모임 2: 광안 풋살 번개
+INSERT INTO meetup (
+    owner_id, name, category, description, participant_count, capacity, score_limit,
+    location_point, address, sgg_code, status, start_at, end_at
+)
+VALUES (
+           (SELECT id FROM profile WHERE nickname = '방장2'),
+           '광안 풋살 번개',
+           'SPORTS',
+           '초보 환영 ⚽ 광안리 풋살장 5대5 경기 예정입니다!',
+           1,
+           12,
+           35.0,
+           ST_GeomFromText('POINT(129.0785 35.2287)', 4326),
+           '부산광역시 수영구 민락동 풋살장',
+           26410,
+           'OPEN',
+           date_trunc('hour', now()) + interval '1 hour' + make_interval(mins => case when extract(minute from now()) >= 30 then 30 else 0 end),
+           date_trunc('hour', now()) + interval '4 hour' + make_interval(mins => case when extract(minute from now()) >= 30 then 30 else 0 end)
+       );
+
+-- 테스트 모임 생성용 계정 3
+-- password: testpass1212!
+INSERT INTO member (email, password, verified)
+VALUES (
+           'meetupowner3@test.com',
+           '$2a$10$c.KAjYSgNz6KLUtG7Qw0B.i/vviGv/FgKvMH7orJFvx8Oh0.wmJ5G',
+           TRUE
+       );
+
+INSERT INTO member_role (member_id, name)
+VALUES (
+           (SELECT id FROM member WHERE email = 'meetupowner3@test.com'),
+           'ROLE_USER'
+       );
+
+INSERT INTO profile (member_id, nickname, age, gender, image_url, description, base_location_id)
+VALUES (
+           (SELECT id FROM member WHERE email = 'meetupowner3@test.com'),
+           '방장3',
+           33,
+           'FEMALE',
+           'https://momeet-dev-bucket-1.s3.ap-northeast-2.amazonaws.com/profiles/meetupOwner3.png',
+           '방장3 테스트 프로필',
+           26260
+       );
+
+-- 🏐 테스트 모임 3: 광안 해변 배구 모임
+INSERT INTO meetup (
+    owner_id, name, category, description, participant_count, capacity, score_limit,
+    location_point, address, sgg_code, status, start_at, end_at
+)
+VALUES (
+           (SELECT id FROM profile WHERE nickname = '방장3'),
+           '광안 해변 배구 모임',
+           'SPORTS',
+           '광안리 해변에서 즐기는 배구 모임! ☀️',
+           1,
+           8,
+           36.5,
+           ST_GeomFromText('POINT(129.1173 35.1534)', 4326),
+           '부산광역시 수영구 광안해변로',
+           26410,
+           'OPEN',
+           date_trunc('hour', now()) + interval '1 hour' + make_interval(mins => case when extract(minute from now()) >= 30 then 30 else 0 end),
+           date_trunc('hour', now()) + interval '4 hour' + make_interval(mins => case when extract(minute from now()) >= 30 then 30 else 0 end)
+       );
+
+-- 🏷 해시태그 추가
+INSERT INTO meetup_hash_tag (meetup_id, name, created_at)
+VALUES
+    ((SELECT id FROM meetup WHERE name = '광안 농구 모임'), '#농구', NOW()),
+    ((SELECT id FROM meetup WHERE name = '광안 농구 모임'), '#운동', NOW()),
+    ((SELECT id FROM meetup WHERE name = '광안 풋살 번개'), '#풋살', NOW()),
+    ((SELECT id FROM meetup WHERE name = '광안 풋살 번개'), '#축구', NOW()),
+    ((SELECT id FROM meetup WHERE name = '광안 해변 배구 모임'), '#배구', NOW()),
+    ((SELECT id FROM meetup WHERE name = '광안 해변 배구 모임'), '#바다', NOW());

--- a/src/main/resources/sql/init_data.sql
+++ b/src/main/resources/sql/init_data.sql
@@ -219,10 +219,29 @@ VALUES (
 
 -- 🏷 해시태그 추가
 INSERT INTO meetup_hash_tag (meetup_id, name, created_at)
-VALUES
-    ((SELECT id FROM meetup WHERE name = '광안 농구 모임'), '#농구', NOW()),
-    ((SELECT id FROM meetup WHERE name = '광안 농구 모임'), '#운동', NOW()),
-    ((SELECT id FROM meetup WHERE name = '광안 풋살 번개'), '#풋살', NOW()),
-    ((SELECT id FROM meetup WHERE name = '광안 풋살 번개'), '#축구', NOW()),
-    ((SELECT id FROM meetup WHERE name = '광안 해변 배구 모임'), '#배구', NOW()),
-    ((SELECT id FROM meetup WHERE name = '광안 해변 배구 모임'), '#바다', NOW());
+SELECT m.id, t.tag, now()
+FROM (
+         VALUES
+             ('광안 농구 모임','방장1','#농구'),
+             ('광안 농구 모임','방장1','#운동'),
+             ('광안 풋살 번개','방장2','#풋살'),
+             ('광안 풋살 번개','방장2','#축구'),
+             ('광안 해변 배구 모임','방장3','#배구'),
+             ('광안 해변 배구 모임','방장3','#바다')
+     ) AS t(meetup_name, owner_nickname, tag)
+         JOIN meetup  m ON m.name = t.meetup_name
+         JOIN profile p ON p.id = m.owner_id AND p.nickname = t.owner_nickname
+;
+
+-- 방장 참가자 추가
+INSERT INTO meetup_participant (meetup_id, profile_id, role, is_active)
+SELECT m.id, p.id, 'HOST', TRUE
+FROM (
+         VALUES
+             ('광안 농구 모임','방장1'),
+             ('광안 풋살 번개','방장2'),
+             ('광안 해변 배구 모임','방장3')
+     ) AS t(meetup_name, owner_nickname)
+         JOIN meetup  m ON m.name = t.meetup_name
+         JOIN profile p ON p.nickname = t.owner_nickname AND p.id = m.owner_id
+;

--- a/src/test/java/com/pnu/momeet/unit/badge/BadgeAutoGrantListenerTest.java
+++ b/src/test/java/com/pnu/momeet/unit/badge/BadgeAutoGrantListenerTest.java
@@ -13,6 +13,7 @@ import com.pnu.momeet.domain.badge.service.BadgeRuleService;
 import com.pnu.momeet.domain.evaluation.enums.Rating;
 import com.pnu.momeet.domain.evaluation.event.EvaluationSubmittedEvent;
 import com.pnu.momeet.domain.meetup.event.MeetupFinishedEvent;
+import com.pnu.momeet.domain.member.enums.Role;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -46,7 +47,8 @@ class BadgeAutoGrantListenerTest {
 
         MeetupFinishedEvent e = new MeetupFinishedEvent(
             meetupId,
-            List.of(p1, p2)
+            List.of(p1, p2),
+            Role.ROLE_USER
         );
 
         // 문자열 리터럴 대신 BadgeRule enum의 code() 사용

--- a/src/test/java/com/pnu/momeet/unit/badge/CoreEventPublisherTest.java
+++ b/src/test/java/com/pnu/momeet/unit/badge/CoreEventPublisherTest.java
@@ -10,6 +10,7 @@ import com.pnu.momeet.common.logging.Source;
 import com.pnu.momeet.domain.evaluation.enums.Rating;
 import com.pnu.momeet.domain.evaluation.event.EvaluationSubmittedEvent;
 import com.pnu.momeet.domain.meetup.event.MeetupFinishedEvent;
+import com.pnu.momeet.domain.member.enums.Role;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -54,7 +55,7 @@ class CoreEventPublisherTest {
     void publish_meetupFinished_delegatesWithSameEvent() {
         // given
         UUID meetupId = UUID.randomUUID();
-        MeetupFinishedEvent event = new MeetupFinishedEvent(meetupId, List.of());
+        MeetupFinishedEvent event = new MeetupFinishedEvent(meetupId, List.of(), Role.ROLE_USER);
 
         ArgumentCaptor<Object> cap = ArgumentCaptor.forClass(Object.class);
 


### PR DESCRIPTION
# Pull Request 템플릿

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 걸어주세요 -->
- Closes #(98)

## 💡 변경 이유
<!-- 왜 이 코드 변경이 필요했나요? 어떤 문제를 해결하거나 어떤 기능을 추가했나요? -->

평가 가능한 사용자 프로필 조회 API 로직에 문제가 있었습니다.

## 📋 주요 변경사항
<!-- 구체적으로 어떤 것들이 변경되었는지 간단히 나열해주세요 -->
- 모임 상태와 24시간 이내에 평가한 사용자를 고려해서 평가 가능한 사용자 프로필을 조회할 수 있도록 수정

## ⚠️ 발견된 위험이나 장애
<!-- 개발 중 발견된 문제점이나 주의할 부분이 있다면 작성해주세요 (없으면  삭제) -->


## 👀 리뷰 포인트
<!-- 리뷰어가 특별히 집중해서 봐야 할 부분을 알려주세요 -->
- 평가 가능한 사용자 프로필 조회 로직이 잘 구현되었는지

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 (없으면 삭제해도 됩니다) -->


## ✅ 테스트 완료 사항
<!-- 어떻게 테스트했는지 간단히 작성해주세요 -->
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
- [x] (기타 테스트 내용)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed evaluation candidate selection to properly enforce 24-hour cooldown between evaluations of the same person.
  * Fixed evaluation retrieval to require meetup completion status before allowing evaluations.

* **Tests**
  * Added test coverage for cooldown exclusion and meetup status validation in evaluation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->