### PR TITLE
Refactor/98 evaluatable user (PR again)

### DIFF
--- a/src/main/java/com/pnu/momeet/domain/evaluation/repository/EvaluationDslRepository.java
+++ b/src/main/java/com/pnu/momeet/domain/evaluation/repository/EvaluationDslRepository.java
@@ -1,9 +1,12 @@
 package com.pnu.momeet.domain.evaluation.repository;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
 public interface EvaluationDslRepository {
     Set<UUID> findEvaluatedMeetupIds(UUID evaluatorId, Collection<UUID> meetupIds);
+    Map<UUID, LocalDateTime> findLastCreatedAtByTargets(UUID evaluatorId, Collection<UUID> targetIds);
 }

--- a/src/main/java/com/pnu/momeet/domain/evaluation/repository/EvaluationDslRepositoryImpl.java
+++ b/src/main/java/com/pnu/momeet/domain/evaluation/repository/EvaluationDslRepositoryImpl.java
@@ -1,13 +1,18 @@
 package com.pnu.momeet.domain.evaluation.repository;
 
 import com.pnu.momeet.domain.evaluation.entity.QEvaluation;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -31,5 +36,30 @@ public class EvaluationDslRepositoryImpl implements EvaluationDslRepository {
             .fetch();
 
         return new HashSet<>(rows);
+    }
+
+    public Map<UUID, LocalDateTime> findLastCreatedAtByTargets(UUID evaluatorId, Collection<UUID> targetIds) {
+        QEvaluation e = QEvaluation.evaluation;
+
+        if (evaluatorId == null || targetIds == null || targetIds.isEmpty()) {
+            return Map.of();
+        }
+
+        DateTimeExpression<LocalDateTime> lastExpr = e.createdAt.max();
+
+        List<Tuple> rows = jpaQueryFactory
+            .select(e.targetProfileId, lastExpr)
+            .from(e)
+            .where(
+                e.evaluatorProfileId.eq(evaluatorId),
+                e.targetProfileId.in(targetIds)
+            )
+            .groupBy(e.targetProfileId)
+            .fetch();
+
+        return rows.stream().collect(Collectors.toMap(
+            t -> t.get(e.targetProfileId),
+            t -> t.get(lastExpr)
+        ));
     }
 }

--- a/src/main/java/com/pnu/momeet/domain/evaluation/service/EvaluationEntityService.java
+++ b/src/main/java/com/pnu/momeet/domain/evaluation/service/EvaluationEntityService.java
@@ -5,10 +5,12 @@ import com.pnu.momeet.domain.evaluation.repository.EvaluationRepository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -38,6 +40,13 @@ public class EvaluationEntityService {
         log.debug("최근 evaluator→target 평가 조회. evaluatorPid={}, targetPid={}, exists={}",
             evaluatorPid, targetPid, found.isPresent());
         return found;
+    }
+
+    @Transactional(readOnly = true)
+    public Map<UUID, LocalDateTime> getLastCreatedAtByTargets(UUID evaluatorPid, Set<UUID> targetPids) {
+        log.debug("모임 참가자들에 대해 최근 생성한 평가 시각 조회. evaluatorPid={}, targetPids={}", evaluatorPid, targetPids);
+        if (targetPids == null || targetPids.isEmpty()) return Map.of();
+        return evaluationRepository.findLastCreatedAtByTargets(evaluatorPid, targetPids);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
# Pull Request 템플릿

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 걸어주세요 -->
- Closes #(98)

## 💡 변경 이유
<!-- 왜 이 코드 변경이 필요했나요? 어떤 문제를 해결하거나 어떤 기능을 추가했나요? -->

이전 PR 코드 리뷰 피드백 반영
https://github.com/kakao-tech-campus-3rd-step3/Team11_BE/pull/99

## 📋 주요 변경사항
<!-- 구체적으로 어떤 것들이 변경되었는지 간단히 나열해주세요 -->
- getEvaluatableUsers 메서드에 참가자 필터링 로직 추가 및 평가 대상에 대한 최근 평가의 createdAt을 한 번에 조회하도록 수정해 N+1 문제 해결

## ⚠️ 발견된 위험이나 장애
<!-- 개발 중 발견된 문제점이나 주의할 부분이 있다면 작성해주세요 (없으면  삭제) -->


## 👀 리뷰 포인트
<!-- 리뷰어가 특별히 집중해서 봐야 할 부분을 알려주세요 -->
- 
- 

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 (없으면 삭제해도 됩니다) -->


## ✅ 테스트 완료 사항
<!-- 어떻게 테스트했는지 간단히 작성해주세요 -->
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
- [x] (기타 테스트 내용)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Added validation to ensure only meetup participants can evaluate other members in the same meetup.
- Corrected meetup status verification logic to accurately determine evaluation eligibility.

**Refactoring**
- Optimized evaluation eligibility checks by implementing batch retrieval of evaluation history, replacing individual lookups for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->