### PR TITLE
Fix/106 revice message

### DIFF
--- a/src/main/java/com/pnu/momeet/domain/chatting/dto/response/MessageResponse.java
+++ b/src/main/java/com/pnu/momeet/domain/chatting/dto/response/MessageResponse.java
@@ -3,11 +3,15 @@ package com.pnu.momeet.domain.chatting.dto.response;
 import com.pnu.momeet.domain.chatting.enums.ChatMessageType;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 public record MessageResponse(
         ChatMessageType type,
         String content,
         Long senderId,
+        UUID profileId,
+        String nickname,
+        String profileImageUrl,
         LocalDateTime sentAt
 ) {
 }

--- a/src/main/java/com/pnu/momeet/domain/chatting/entity/ChatMessage.java
+++ b/src/main/java/com/pnu/momeet/domain/chatting/entity/ChatMessage.java
@@ -24,10 +24,12 @@ public class ChatMessage extends SimpleCreationEntity {
     private Meetup meetup;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.SET_NULL)
     @JoinColumn(name = "sender_id")
     private Participant sender;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.SET_NULL)
     @JoinColumn(name = "profile_id")
     private Profile profile;
 

--- a/src/main/java/com/pnu/momeet/domain/chatting/repository/ChatMessageDslRepositoryImpl.java
+++ b/src/main/java/com/pnu/momeet/domain/chatting/repository/ChatMessageDslRepositoryImpl.java
@@ -28,7 +28,7 @@ public class ChatMessageDslRepositoryImpl implements ChatMessageDslRepository{
 
         List<ChatMessage> content = jpaQueryFactory
                 .selectFrom(chatMessage)
-                .join(chatMessage.profile, profile).fetchJoin()
+                .leftJoin(chatMessage.profile, profile).fetchJoin()
                 .where(condition)
                 .orderBy(chatMessage.id.desc())
                 .limit(size + 1)

--- a/src/main/java/com/pnu/momeet/domain/chatting/repository/ChatMessageDslRepositoryImpl.java
+++ b/src/main/java/com/pnu/momeet/domain/chatting/repository/ChatMessageDslRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.pnu.momeet.domain.chatting.repository;
 import com.pnu.momeet.domain.chatting.entity.ChatMessage;
 import com.pnu.momeet.domain.chatting.entity.QChatMessage;
 import com.pnu.momeet.domain.common.dto.response.CursorInfo;
+import com.pnu.momeet.domain.profile.entity.QProfile;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ public class ChatMessageDslRepositoryImpl implements ChatMessageDslRepository{
 
     public CursorInfo<ChatMessage> findHistoriesByMeetupId(UUID meetupId, int size, Long cursorId) {
         QChatMessage chatMessage = QChatMessage.chatMessage;
+        QProfile profile = QProfile.profile;
 
         BooleanExpression condition = chatMessage.meetup.id.eq(meetupId);
         if (cursorId != null) {
@@ -26,6 +28,7 @@ public class ChatMessageDslRepositoryImpl implements ChatMessageDslRepository{
 
         List<ChatMessage> content = jpaQueryFactory
                 .selectFrom(chatMessage)
+                .join(chatMessage.profile, profile).fetchJoin()
                 .where(condition)
                 .orderBy(chatMessage.id.desc())
                 .limit(size + 1)

--- a/src/main/java/com/pnu/momeet/domain/chatting/service/mapper/ChatEntityMapper.java
+++ b/src/main/java/com/pnu/momeet/domain/chatting/service/mapper/ChatEntityMapper.java
@@ -6,8 +6,6 @@ import com.pnu.momeet.domain.chatting.entity.ChatMessage;
 import com.pnu.momeet.domain.chatting.enums.ChatActionType;
 import com.pnu.momeet.domain.participant.entity.Participant;
 
-import java.util.UUID;
-
 public class ChatEntityMapper {
 
     private ChatEntityMapper() {
@@ -40,6 +38,10 @@ public class ChatEntityMapper {
     }
 
     public static ActionResponse toAction(Participant participant, ChatActionType actionType) {
+        if (participant.getProfile() == null) {
+            return toAction(participant.getId(), actionType);
+        }
+
         return new ActionResponse(
                 participant.getId(),
                 participant.getProfile().getId(),

--- a/src/main/java/com/pnu/momeet/domain/chatting/service/mapper/ChatEntityMapper.java
+++ b/src/main/java/com/pnu/momeet/domain/chatting/service/mapper/ChatEntityMapper.java
@@ -6,16 +6,35 @@ import com.pnu.momeet.domain.chatting.entity.ChatMessage;
 import com.pnu.momeet.domain.chatting.enums.ChatActionType;
 import com.pnu.momeet.domain.participant.entity.Participant;
 
+import java.util.UUID;
+
 public class ChatEntityMapper {
 
     private ChatEntityMapper() {
         // private constructor to prevent instantiation
     }
     public static MessageResponse toMessage(ChatMessage message) {
+        Long senderId = message.getSender() != null ? message.getSender().getId() : null;
+
+        if (message.getProfile() == null) {
+            return new MessageResponse(
+                    message.getType(),
+                    message.getContent(),
+                    senderId,
+                    null,
+                    null,
+                    null,
+                    message.getCreatedAt()
+            );
+        }
+
         return new MessageResponse(
                 message.getType(),
                 message.getContent(),
-                message.getSender().getId(),
+                senderId,
+                message.getProfile().getId(),
+                message.getProfile().getNickname(),
+                message.getProfile().getImageUrl(),
                 message.getCreatedAt()
         );
     }

--- a/src/main/resources/sql/init_scheme.sql
+++ b/src/main/resources/sql/init_scheme.sql
@@ -137,7 +137,7 @@ CREATE TABLE chat_message (
     id              BIGSERIAL PRIMARY KEY,
     meetup_id       UUID NOT NULL REFERENCES meetup(id) ON DELETE CASCADE,
     sender_id       BIGINT REFERENCES meetup_participant(id) ON DELETE SET NULL,
-    profile_id      UUID NOT NULL REFERENCES profile(id) ON DELETE SET NULL,
+    profile_id      UUID REFERENCES profile(id) ON DELETE SET NULL,
     message_type    VARCHAR(20) NOT NULL,  -- TEXT/IMAGE/SYSTEM
     content         TEXT NOT NULL,
     created_at      TIMESTAMP NOT NULL DEFAULT NOW()

--- a/src/test/resources/sql/test_init_scheme.sql
+++ b/src/test/resources/sql/test_init_scheme.sql
@@ -126,7 +126,7 @@ CREATE TABLE public_test.chat_message (
     id              BIGSERIAL PRIMARY KEY,
     meetup_id       UUID NOT NULL REFERENCES public_test.meetup(id) ON DELETE CASCADE,
     sender_id       BIGINT REFERENCES public_test.meetup_participant(id) ON DELETE SET NULL,
-    profile_id      UUID NOT NULL REFERENCES public_test.profile(id) ON DELETE SET NULL,
+    profile_id      UUID REFERENCES public_test.profile(id) ON DELETE SET NULL,
     message_type    VARCHAR(20) NOT NULL,
     content         TEXT NOT NULL,
     created_at      TIMESTAMP NOT NULL DEFAULT NOW()


### PR DESCRIPTION
# Pull Request 템플릿

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 걸어주세요 -->
- Closes #006

## 💡 변경 이유
<!-- 왜 이 코드 변경이 필요했나요? 어떤 문제를 해결하거나 어떤 기능을 추가했나요? -->
message 히스토리 조회시 500 에러가 발생했습니다.
또한 별도로 회원이 나갔을 경우에도 profile 정보를 조회할 수 있도록 구현해야헀습니다.

## 📋 주요 변경사항
<!-- 구체적으로 어떤 것들이 변경되었는지 간단히 나열해주세요 -->
-  message Response에 프로파일 정보 추가
-  message의 속성들이 null 경우의 처리
-  fetch join을 통해 다건 히스토리 조회 시 N+1 문제 해결

## ⚠️ 발견된 위험이나 장애
<!-- 개발 중 발견된 문제점이나 주의할 부분이 있다면 작성해주세요 (없으면  삭제) -->

회원 탈퇴 시 제대로 메시지가 처리 되지 않았습니다. leftjoin을 통해 profile이 null 경우에도 가져올 수 있도록 수정했습니다.

## 👀 리뷰 포인트
<!-- 리뷰어가 특별히 집중해서 봐야 할 부분을 알려주세요 -->
- 추가적인 문제는 없는지


## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 (없으면 삭제해도 됩니다) -->

<img width="1195" height="342" alt="image" src="https://github.com/user-attachments/assets/dc397bbf-42c6-47d0-8a40-a236c0cef89a" />

## ✅ 테스트 완료 사항
<!-- 어떻게 테스트했는지 간단히 작성해주세요 -->
- [X] 로컬에서 정상 동작 확인
- [X] 기존 기능에 영향 없음 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Chat messages now show profile details (nickname and profile image) alongside sender info.
  * Message payloads include a persistent profile identifier for richer display.

* **Bug Fixes**
  * App now handles missing or deleted profiles gracefully (profile fields become null instead of breaking).
  * Chat history loads profile data more reliably for display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->