### PR TITLE
feat(s3): 이미지 제공을 CloudFront(OAC)로 전환하고 CDN URL 반환으로 통일 및 테스트 데이터 수정 …

### DIFF
--- a/src/main/java/com/pnu/momeet/common/service/S3StorageService.java
+++ b/src/main/java/com/pnu/momeet/common/service/S3StorageService.java
@@ -29,6 +29,10 @@ public class S3StorageService {
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucket;
 
+    // CloudFront(or 도메인) 베이스 URL
+    @Value("${frontend.url}")
+    private String cdnBaseUrl;
+
     public String uploadImage(MultipartFile multipartFile, String prefix) {
         return uploadImageToS3(multipartFile, prefix);
     }
@@ -69,7 +73,10 @@ public class S3StorageService {
             throw new StorageException("파일 저장 중 오류가 발생했습니다.");
         }
 
-        return s3Client.utilities().getUrl(url -> url.bucket(bucket).key(key)).toString();
+        // CloudFront URL 반환
+        return cdnBaseUrl.endsWith("/")
+            ? cdnBaseUrl + key
+            : cdnBaseUrl + "/" + key;
     }
 
     private String getKeyFromImageUrl(String url) {

--- a/src/main/resources/sql/init_data.sql
+++ b/src/main/resources/sql/init_data.sql
@@ -46,7 +46,7 @@ VALUES (
         '앨리스',
         24,
         'FEMALE',
-        'https://momeet-dev-bucket-1.s3.ap-northeast-2.amazonaws.com/profiles/alice.png',
+        'https://www.momeet.click/profiles/alice.png',
         '보드게임/카페 모임 좋아해요 ☕',
         26410
        );
@@ -71,7 +71,7 @@ VALUES (
         '크리스',
         27,
         'MALE',
-        'https://momeet-dev-bucket-1.s3.ap-northeast-2.amazonaws.com/profiles/chris.png',
+        'https://www.momeet.click/profiles/chris.png',
         '풋살·등산 러버 🏔️',
         26260
        );
@@ -82,7 +82,7 @@ INSERT INTO badge (
     gen_random_uuid(),
     '모임 새싹',
     '모임 첫 참여 배지',
-    'https://momeet-dev-bucket-1.s3.ap-northeast-2.amazonaws.com/badges/meetup-first.png',
+    'https://www.momeet.click/badges/meetup-first.png',
     'FIRST_JOIN',
     now(),
     now()
@@ -94,7 +94,7 @@ INSERT INTO badge (
     gen_random_uuid(),
     '모임 고수',
     '모임 10회 참여 배지',
-    'https://momeet-dev-bucket-1.s3.ap-northeast-2.amazonaws.com/badges/meetup-ten.png',
+    'https://www.momeet.click/badges/meetup-ten.png',
     'TEN_JOINS',
     now(),
     now()
@@ -106,7 +106,7 @@ INSERT INTO badge (
     gen_random_uuid(),
     '호감 인기인',
     '좋아요 10개',
-    'https://momeet-dev-bucket-1.s3.ap-northeast-2.amazonaws.com/badges/like-five.png',
+    'https://www.momeet.click/badges/like-five.png',
     'LIKE_10',
     now(),
     now()
@@ -118,7 +118,7 @@ INSERT INTO badge (
     gen_random_uuid(),
     '[TEST] 테스트용 배지 1',
     '테스트용 배지 1',
-    'https://momeet-dev-bucket-1.s3.ap-northeast-2.amazonaws.com/badges/test-1.png',
+    'https://www.momeet.click/badges/test-1.png',
     'TEST_1',
     now(),
     now()
@@ -130,7 +130,7 @@ INSERT INTO badge (
     gen_random_uuid(),
     '[TEST] 테스트용 배지 2',
     '테스트용 배지 2',
-    'https://momeet-dev-bucket-1.s3.ap-northeast-2.amazonaws.com/badges/test-2.png',
+    'https://www.momeet.click/badges/test-2.png',
     'TEST_2',
     now(),
     now()
@@ -142,7 +142,7 @@ INSERT INTO badge (
     gen_random_uuid(),
     '[TEST] 테스트용 배지 3',
     '테스트용 배지 3',
-    'https://momeet-dev-bucket-1.s3.ap-northeast-2.amazonaws.com/badges/test-3.png',
+    'https://www.momeet.click/badges/test-3.png',
     'TEST_3',
     now(),
     now()
@@ -205,7 +205,7 @@ VALUES (
     '방장1',
     30,
     'MALE',
-    'https://momeet-dev-bucket-1.s3.ap-northeast-2.amazonaws.com/profiles/meetupOwner.png',
+    'https://www.momeet.click/profiles/meetupOwner.png',
     '방장1 테스트 프로필',
     26260
 );
@@ -252,7 +252,7 @@ VALUES (
     '방장2',
     50,
     'MALE',
-    'https://momeet-dev-bucket-1.s3.ap-northeast-2.amazonaws.com/profiles/meetupOwner2.png',
+    'https://www.momeet.click/profiles/meetupOwner2.png',
     '방장2 테스트 프로필',
     26260
 );
@@ -299,7 +299,7 @@ VALUES (
            '방장3',
            33,
            'FEMALE',
-           'https://momeet-dev-bucket-1.s3.ap-northeast-2.amazonaws.com/profiles/meetupOwner3.png',
+           'https://www.momeet.click/profiles/meetupOwner3.png',
            '방장3 테스트 프로필',
            26260
        );


### PR DESCRIPTION
# Pull Request 템플릿

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 걸어주세요 -->
- Closes #(115)

## 💡 변경 이유
<!-- 왜 이 코드 변경이 필요했나요? 어떤 문제를 해결하거나 어떤 기능을 추가했나요? -->

S3 버킷에 Block Public Access 적용 및 .acl(PUBLIC_READ) 제거 이후, 프론트가 S3 퍼블릭 URL을 직접 <img src>로 조회 → 403(AccessDenied) 발생.

CloudFront + OAC 설정 : S3는 사설 유지, CloudFront만 읽기 허용하고, 백엔드는 CDN URL을 내려 프론트가 그대로 표시하도록 개선.

## 📋 주요 변경사항
<!-- 구체적으로 어떤 것들이 변경되었는지 간단히 나열해주세요 -->
- BE 코드
  - S3StorageService
    - 업로드 후 반환값을 S3 URL → CDN URL(frontend.url + "/" + key) 로 변경.
    - deleteImage(url)은 URL의 path에서 key 추출(CloudFront/S3 URL 모두 지원).
    - 캐시 최적화 헤더 유지: Cache-Control: public, max-age=31536000, immutable.
  - 설정
    - momeet.cdn-base-url = ${frontend.url}로 주입(운영: https://www.momeet.click).
- 인프라(배포 재사용)
  - 기존 CloudFront 배포 재사용, 업로드 버킷 오리진 추가 + OAC 연결.
  - 비헤이비어 추가:
    - `/profiles/*`, `/badges/*`, `/reports/*` → 업로드 버킷 오리진
    - 우선순위: 각 경로가 기본값(*)보다 위
    - Origin path 비움(경로 이중 접두사 방지)
    - 버킷 정책: 해당 Distribution ARN만 s3:GetObject 허용.

## ⚠️ 발견된 위험이나 장애
<!-- 개발 중 발견된 문제점이나 주의할 부분이 있다면 작성해주세요 (없으면  삭제) -->

S3에 참조하는 키가 실제 없을 경우 404(예: `profiles/chris.png`). → 대응: seed/데이터 정합성 점검 + 프론트 fallback 이미지 적용.

## 👀 리뷰 포인트
<!-- 리뷰어가 특별히 집중해서 봐야 할 부분을 알려주세요 -->
- S3StorageService의 반환 URL 조립 로직이 올바른지

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 (없으면 삭제해도 됩니다) -->
<img width="670" height="742" alt="image" src="https://github.com/user-attachments/assets/e6c9ef9f-2b40-44fb-ad1c-9254791e8378" />
<img width="1920" height="1034" alt="image" src="https://github.com/user-attachments/assets/434cde88-86e8-421e-9fc4-ee144f8b2480" />

## ✅ 테스트 완료 사항
<!-- 어떻게 테스트했는지 간단히 작성해주세요 -->
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
- [x] (기타 테스트 내용)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated image and icon delivery infrastructure to use CDN-based distribution for profile images and badge icons.
  * Migrated asset URLs to new domain infrastructure for improved performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->