### PR TITLE
Refactor/119 block

### DIFF
--- a/src/main/java/com/pnu/momeet/domain/block/controller/BlockController.java
+++ b/src/main/java/com/pnu/momeet/domain/block/controller/BlockController.java
@@ -40,23 +40,23 @@ public class BlockController {
     }
 
     @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
-    @PostMapping({"/{targetId}"})
+    @PostMapping({"/{targetProfileId}"})
     public ResponseEntity<BlockResponse> blockUser(
         @AuthenticationPrincipal CustomUserDetails userDetails,
-        @PathVariable UUID targetId
+        @PathVariable UUID targetProfileId
     ) {
         return ResponseEntity
             .status(HttpStatus.CREATED)
-            .body(blockService.createUserBlock(userDetails.getMemberId(), targetId));
+            .body(blockService.createUserBlock(userDetails.getMemberId(), targetProfileId));
     }
 
     @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
-    @DeleteMapping({"/{targetId}"})
+    @DeleteMapping({"/{targetProfileId}"})
     public ResponseEntity<Void> delete(
         @AuthenticationPrincipal CustomUserDetails userDetails,
-        @PathVariable UUID targetId
+        @PathVariable UUID targetProfileId
     ) {
-        blockService.deleteBlock(userDetails.getMemberId(), targetId);
+        blockService.deleteBlock(userDetails.getMemberId(), targetProfileId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/pnu/momeet/domain/block/dto/response/BlockResponse.java
+++ b/src/main/java/com/pnu/momeet/domain/block/dto/response/BlockResponse.java
@@ -4,8 +4,8 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record BlockResponse(
-    UUID blockerId,
-    UUID blockedId,
+    UUID blockerProfileId,
+    UUID blockedProfileId,
     LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/com/pnu/momeet/domain/block/entity/UserBlock.java
+++ b/src/main/java/com/pnu/momeet/domain/block/entity/UserBlock.java
@@ -17,13 +17,13 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserBlock extends BaseCreatedEntity {
 
-    @Column(name = "blocker_id", nullable = false)
-    private UUID blockerId;
+    @Column(name = "blocker_profile_id", nullable = false)
+    private UUID blockerProfileId;
 
-    @Column(name = "blocked_id", nullable = false)
-    private UUID blockedId;
+    @Column(name = "blocked_profile_id", nullable = false)
+    private UUID blockedProfileId;
 
-    public static UserBlock create(UUID blockerId, UUID blockedId) {
-        return new UserBlock(blockerId, blockedId);
+    public static UserBlock create(UUID blockerProfileId, UUID blockedProfileId) {
+        return new UserBlock(blockerProfileId, blockedProfileId);
     }
 }

--- a/src/main/java/com/pnu/momeet/domain/block/mapper/BlockEntityMapper.java
+++ b/src/main/java/com/pnu/momeet/domain/block/mapper/BlockEntityMapper.java
@@ -7,8 +7,8 @@ public class BlockEntityMapper {
 
     public static BlockResponse toBlockResponse(UserBlock block) {
         return new BlockResponse(
-            block.getBlockerId(),
-            block.getBlockedId(),
+            block.getBlockerProfileId(),
+            block.getBlockedProfileId(),
             block.getCreatedAt()
         );
     }

--- a/src/main/java/com/pnu/momeet/domain/block/repository/BlockRepository.java
+++ b/src/main/java/com/pnu/momeet/domain/block/repository/BlockRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BlockRepository extends JpaRepository<UserBlock, UUID> {
 
-    boolean existsByBlockerProfileIdAndBlockedProfileId(UUID blockerId, UUID blockedId);
-    long deleteByBlockerProfileIdAndBlockedProfileId(UUID blockerId, UUID blockedId);
+    boolean existsByBlockerProfileIdAndBlockedProfileId(UUID blockerProfileId, UUID blockedProfileId);
+    long deleteByBlockerProfileIdAndBlockedProfileId(UUID blockerProfileId, UUID blockedProfileId);
 }

--- a/src/main/java/com/pnu/momeet/domain/block/repository/BlockRepository.java
+++ b/src/main/java/com/pnu/momeet/domain/block/repository/BlockRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BlockRepository extends JpaRepository<UserBlock, UUID> {
 
-    boolean existsByBlockerIdAndBlockedId(UUID blockerId, UUID blockedId);
-    long deleteByBlockerIdAndBlockedId(UUID blockerId, UUID blockedId);
+    boolean existsByBlockerProfileIdAndBlockedProfileId(UUID blockerId, UUID blockedId);
+    long deleteByBlockerProfileIdAndBlockedProfileId(UUID blockerId, UUID blockedId);
 }

--- a/src/main/java/com/pnu/momeet/domain/block/service/BlockDomainService.java
+++ b/src/main/java/com/pnu/momeet/domain/block/service/BlockDomainService.java
@@ -7,18 +7,16 @@ import com.pnu.momeet.domain.block.mapper.BlockEntityMapper;
 import com.pnu.momeet.domain.block.service.mapper.BlockDtoMapper;
 import com.pnu.momeet.domain.member.service.MemberEntityService;
 import com.pnu.momeet.domain.profile.dto.response.BlockedProfileResponse;
+import com.pnu.momeet.domain.profile.entity.Profile;
 import com.pnu.momeet.domain.profile.service.ProfileEntityService;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.server.ResponseStatusException;
 
 @Slf4j
 @Service
@@ -26,7 +24,6 @@ import org.springframework.web.server.ResponseStatusException;
 public class BlockDomainService {
 
     private final BlockEntityService entityService;
-    private final MemberEntityService memberService;
     private final ProfileEntityService profileService;
 
     @Transactional(readOnly = true)
@@ -34,39 +31,42 @@ public class BlockDomainService {
         UUID me,
         BlockPageRequest pageRequest
     ) {
-        log.debug("차단 목록 조회 시도. blockerId={}", me);
+        Profile myProfile = profileService.getByMemberId(me);
+        log.debug("차단 목록 조회 시도. blockerProfileId={}", myProfile.getId());
         PageRequest page = BlockDtoMapper.toPageRequest(pageRequest);
-        Page<BlockedProfileResponse> blockedProfiles = profileService.getBlockedProfiles(me, page);
-        log.debug("차단 목록 조회 성공. blockerId={}", me);
+        Page<BlockedProfileResponse> blockedProfiles = profileService.getBlockedProfiles(myProfile.getId(), page);
+        log.debug("차단 목록 조회 성공. blockerProfileId={}", myProfile.getId());
         return blockedProfiles;
     }
 
     @Transactional
-    public BlockResponse createUserBlock(UUID me, UUID targetId) {
+    public BlockResponse createUserBlock(UUID me, UUID targetProfileId) {
+        Profile myProfile = profileService.getByMemberId(me);
         // 1. 자기 자신 차단 금지
-        if (me.equals(targetId)) {
-            log.info("자기 자신 차단 시도. blockerId={}, blockedId={}", me, targetId);
+        if (myProfile.getId().equals(targetProfileId)) {
+            log.info("자기 자신 차단 시도. blockerProfileId={}, blockedProfileId={}", myProfile.getId(), targetProfileId);
             throw new IllegalArgumentException("자기 자신은 차단할 수 없습니다.");
         }
-        // 2. 대상 회원 존재 검증
-        if (!memberService.existsById(targetId)) {
-            log.info("차단 대상 사용자 조회 실패. blockerId={}, blockedId={}", me, targetId);
-            throw new NoSuchElementException("대상 사용자를 찾을 수 없습니다.");
+        // 2. 대상 회원 프로필 존재 검증
+        if (!profileService.existsById(targetProfileId)) {
+            log.info("차단 대상 사용자 프로필 조회 실패. blockerProfileId={}, blockedProfileId={}", myProfile.getId(), targetProfileId);
+            throw new NoSuchElementException("대상 사용자 프로필을 찾을 수 없습니다.");
         }
         // 3. 이미 차단한 사용자면 금지
-        if (entityService.exists(me, targetId)) {
-            log.info("이미 차단한 사용자 차단 시도. blockerId={}, blockedId={}", me, targetId);
-            throw new IllegalStateException("이미 차단한 사용자입니다.");
+        if (entityService.exists(myProfile.getId(), targetProfileId)) {
+            log.info("이미 차단한 사용자 프로필 차단 시도. blockerProfileId={}, blockedProfileId={}", myProfile.getId(), targetProfileId);
+            throw new IllegalStateException("이미 차단한 사용자 프로필입니다.");
         }
 
-        UserBlock block = entityService.save(me, targetId);
-        log.info("차단 완료. blockerId={}, blockedId={}", me, targetId);
+        UserBlock block = entityService.save(myProfile.getId(), targetProfileId);
+        log.info("차단 완료. blockerProfileId={}, blockedProfileId={}", myProfile.getId(), targetProfileId);
         return BlockEntityMapper.toBlockResponse(block);
     }
 
     @Transactional
-    public void deleteBlock(UUID me, UUID targetId) {
-        entityService.delete(me, targetId);
-        log.info("차단 해제 완료. blockerId={}, blockedId={}", me, targetId);
+    public void deleteBlock(UUID me, UUID targetProfileId) {
+        Profile myProfile = profileService.getByMemberId(me);
+        entityService.delete(myProfile.getId(), targetProfileId);
+        log.info("차단 해제 완료. blockerProfileId={}, blockedProfileId={}", myProfile.getId(), targetProfileId);
     }
 }

--- a/src/main/java/com/pnu/momeet/domain/block/service/BlockEntityService.java
+++ b/src/main/java/com/pnu/momeet/domain/block/service/BlockEntityService.java
@@ -17,20 +17,20 @@ public class BlockEntityService {
 
     @Transactional(readOnly = true)
     public boolean exists(UUID blockerId, UUID blockedId) {
-        return blockRepository.existsByBlockerIdAndBlockedId(blockerId, blockedId);
+        return blockRepository.existsByBlockerProfileIdAndBlockedProfileId(blockerId, blockedId);
     }
 
     @Transactional
-    public UserBlock save(UUID blockerId, UUID blockedId) {
-        log.debug("특정 사용자 차단 시도. blockerId={}, blockedId={}", blockerId, blockedId);
-        UserBlock block = UserBlock.create(blockerId, blockedId);
+    public UserBlock save(UUID blockerProfileId, UUID blockedProfileId) {
+        log.debug("특정 사용자 프로필 차단 시도. blockerProfileId={}, blockedProfileId={}", blockerProfileId, blockedProfileId);
+        UserBlock block = UserBlock.create(blockerProfileId, blockedProfileId);
         UserBlock saved = blockRepository.save(block);
-        log.debug("특정 사용자 차단 성공. blockerId={}, blockedId={}", blockerId, blockedId);
+        log.debug("특정 사용자 프로필 차단 성공. blockerProfileId={}, blockedProfileId={}", blockerProfileId, blockedProfileId);
         return saved;
     }
 
     @Transactional
-    public long delete(UUID blockerId, UUID blockedId) {
-        return blockRepository.deleteByBlockerIdAndBlockedId(blockerId, blockedId);
+    public long delete(UUID blockerProfileId, UUID blockedProfileId) {
+        return blockRepository.deleteByBlockerProfileIdAndBlockedProfileId(blockerProfileId, blockedProfileId);
     }
 }

--- a/src/main/java/com/pnu/momeet/domain/block/service/BlockEntityService.java
+++ b/src/main/java/com/pnu/momeet/domain/block/service/BlockEntityService.java
@@ -16,8 +16,8 @@ public class BlockEntityService {
     private final BlockRepository blockRepository;
 
     @Transactional(readOnly = true)
-    public boolean exists(UUID blockerId, UUID blockedId) {
-        return blockRepository.existsByBlockerProfileIdAndBlockedProfileId(blockerId, blockedId);
+    public boolean exists(UUID blockerProfileId, UUID blockedProfileId) {
+        return blockRepository.existsByBlockerProfileIdAndBlockedProfileId(blockerProfileId, blockedProfileId);
     }
 
     @Transactional

--- a/src/main/java/com/pnu/momeet/domain/meetup/repository/MeetupDslRepository.java
+++ b/src/main/java/com/pnu/momeet/domain/meetup/repository/MeetupDslRepository.java
@@ -19,7 +19,7 @@ public interface MeetupDslRepository {
             double radius,
             @Nullable MainCategory category,
             @Nullable String keyword,
-            UUID viewerMemberId
+            UUID viewerProfileId
     );
 
     List<Meetup> findAllByOwnerIdAndStatusIn(UUID profileId, List<MeetupStatus> statuses);
@@ -39,5 +39,5 @@ public interface MeetupDslRepository {
             Pageable pageable
     );
 
-    boolean existsBlockedInMeetup(UUID meetupId, UUID viewerMemberId);
+    boolean existsBlockedInMeetup(UUID meetupId, UUID viewerProfileId);
 }

--- a/src/main/java/com/pnu/momeet/domain/meetup/repository/MeetupDslRepositoryImpl.java
+++ b/src/main/java/com/pnu/momeet/domain/meetup/repository/MeetupDslRepositoryImpl.java
@@ -50,7 +50,7 @@ public class MeetupDslRepositoryImpl implements MeetupDslRepository {
             double radius,
             @Nullable MainCategory category,
             @Nullable String keyword,
-            UUID viewerMemberId
+            UUID viewerProfileId
     ) {
         QMeetup meetup = QMeetup.meetup;
         QParticipant participant = QParticipant.participant;
@@ -73,15 +73,15 @@ public class MeetupDslRepositoryImpl implements MeetupDslRepository {
         // 차단 제외 조건
         BooleanExpression blockedWithOwner = JPAExpressions.selectOne().from(userBlock)
             .where(
-                userBlock.blockerId.eq(viewerMemberId).and(userBlock.blockedId.eq(meetup.owner.memberId))
-                    .or(userBlock.blockerId.eq(meetup.owner.memberId).and(userBlock.blockedId.eq(viewerMemberId)))
+                userBlock.blockerProfileId.eq(viewerProfileId).and(userBlock.blockedProfileId.eq(meetup.owner.id))
+                    .or(userBlock.blockerProfileId.eq(meetup.owner.id).and(userBlock.blockedProfileId.eq(viewerProfileId)))
             ).exists();
 
         BooleanExpression blockedWithAnyParticipant = JPAExpressions.selectOne()
             .from(participant)
             .join(userBlock).on(
-                userBlock.blockerId.eq(viewerMemberId).and(userBlock.blockedId.eq(participant.profile.memberId))
-                    .or(userBlock.blockerId.eq(participant.profile.memberId).and(userBlock.blockedId.eq(viewerMemberId)))
+                userBlock.blockerProfileId.eq(viewerProfileId).and(userBlock.blockedProfileId.eq(participant.profile.id))
+                    .or(userBlock.blockerProfileId.eq(participant.profile.id).and(userBlock.blockedProfileId.eq(viewerProfileId)))
             )
             .where(participant.meetup.id.eq(meetup.id))
             .exists();
@@ -214,7 +214,7 @@ public class MeetupDslRepositoryImpl implements MeetupDslRepository {
         return new PageImpl<>(content, pageable, (total == null) ? 0 : total);
     }
 
-    public boolean existsBlockedInMeetup(UUID meetupId, UUID viewerMemberId) {
+    public boolean existsBlockedInMeetup(UUID meetupId, UUID viewerProfileId) {
         QMeetup m = QMeetup.meetup;
         QParticipant p = QParticipant.participant;
         QUserBlock ub = QUserBlock.userBlock;
@@ -222,8 +222,8 @@ public class MeetupDslRepositoryImpl implements MeetupDslRepository {
         // owner 차단
         BooleanExpression ownerBlocked = JPAExpressions.selectOne().from(m).join(ub)
             .on(
-                ub.blockerId.eq(viewerMemberId).and(ub.blockedId.eq(m.owner.memberId))
-                    .or(ub.blockerId.eq(m.owner.memberId).and(ub.blockedId.eq(viewerMemberId)))
+                ub.blockerProfileId.eq(viewerProfileId).and(ub.blockedProfileId.eq(m.owner.id))
+                    .or(ub.blockerProfileId.eq(m.owner.id).and(ub.blockedProfileId.eq(viewerProfileId)))
             )
             .where(m.id.eq(meetupId))
             .exists();
@@ -231,8 +231,8 @@ public class MeetupDslRepositoryImpl implements MeetupDslRepository {
         // 참가자 중 1명이라도 차단
         BooleanExpression anyParticipantBlocked = JPAExpressions.selectOne().from(p).join(ub)
             .on(
-                ub.blockerId.eq(viewerMemberId).and(ub.blockedId.eq(p.profile.memberId))
-                    .or(ub.blockerId.eq(p.profile.memberId).and(ub.blockedId.eq(viewerMemberId)))
+                ub.blockerProfileId.eq(viewerProfileId).and(ub.blockedProfileId.eq(p.profile.id))
+                    .or(ub.blockerProfileId.eq(p.profile.id).and(ub.blockedProfileId.eq(viewerProfileId)))
             )
             .where(p.meetup.id.eq(meetupId))
             .exists();

--- a/src/main/java/com/pnu/momeet/domain/meetup/repository/spec/MeetupSpecifications.java
+++ b/src/main/java/com/pnu/momeet/domain/meetup/repository/spec/MeetupSpecifications.java
@@ -13,7 +13,7 @@ import org.springframework.data.jpa.domain.Specification;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class MeetupSpecifications {
 
-    public static Specification<Meetup> visibleTo(UUID viewerMemberId) {
+    public static Specification<Meetup> visibleTo(UUID viewerProfileId) {
         return (root, query, cb) -> {
             // owner - viewer 차단 존재 여부
             Subquery<Integer> ownerBlocked = query.subquery(Integer.class);
@@ -21,12 +21,12 @@ public final class MeetupSpecifications {
             ownerBlocked.select(cb.literal(1))
                 .where(cb.or(
                     cb.and(
-                        cb.equal(ub1.get("blockerId"), viewerMemberId),
-                        cb.equal(ub1.get("blockedId"), root.get("owner").get("memberId"))
+                        cb.equal(ub1.get("blockerProfileId"), viewerProfileId),
+                        cb.equal(ub1.get("blockedProfileId"), root.get("owner").get("id"))
                     ),
                     cb.and(
-                        cb.equal(ub1.get("blockerId"), root.get("owner").get("memberId")),
-                        cb.equal(ub1.get("blockedId"), viewerMemberId)
+                        cb.equal(ub1.get("blockerProfileId"), root.get("owner").get("id")),
+                        cb.equal(ub1.get("blockedProfileId"), viewerProfileId)
                     )
                 ));
 
@@ -39,12 +39,12 @@ public final class MeetupSpecifications {
                     cb.equal(p.get("meetup").get("id"), root.get("id")),
                     cb.or(
                         cb.and(
-                            cb.equal(ub2.get("blockerId"), viewerMemberId),
-                            cb.equal(ub2.get("blockedId"), p.get("profile").get("memberId"))
+                            cb.equal(ub2.get("blockerProfileId"), viewerProfileId),
+                            cb.equal(ub2.get("blockedProfileId"), p.get("profile").get("id"))
                         ),
                         cb.and(
-                            cb.equal(ub2.get("blockerId"), p.get("profile").get("memberId")),
-                            cb.equal(ub2.get("blockedId"), viewerMemberId)
+                            cb.equal(ub2.get("blockerProfileId"), p.get("profile").get("id")),
+                            cb.equal(ub2.get("blockedProfileId"), viewerProfileId)
                         )
                     )
                 );

--- a/src/main/java/com/pnu/momeet/domain/meetup/service/MeetupDomainService.java
+++ b/src/main/java/com/pnu/momeet/domain/meetup/service/MeetupDomainService.java
@@ -90,9 +90,10 @@ public class MeetupDomainService {
         Point locationPoint = geometryFactory.createPoint(new Coordinate(request.longitude(), request.latitude()));
         MainCategory mainCategory = (request.category() != null) ? MainCategory.valueOf(request.category()) : null;
         String search = request.search();
+        Profile viewerProfile = profileService.getByMemberId(viewerMemberId);
 
         return entityService.getAllByLocationAndCondition(
-            locationPoint, request.radius(), mainCategory, search, viewerMemberId
+            locationPoint, request.radius(), mainCategory, search, viewerProfile.getId()
         )
             .stream()
             .map(MeetupEntityMapper::toResponse)
@@ -105,8 +106,9 @@ public class MeetupDomainService {
         UUID viewerMemberId
     ) {
         PageRequest pageRequest = MeetupDtoMapper.toPageRequest(request);
+        Profile viewerProfile = profileService.getByMemberId(viewerMemberId);
         Specification<Meetup> specification = MeetupDtoMapper.toSpecification(request)
-            .and(MeetupSpecifications.visibleTo(viewerMemberId));
+            .and(MeetupSpecifications.visibleTo(viewerProfile.getId()));
 
         Page<Meetup> page = entityService.getAllBySpecificationWithPagination(specification, pageRequest);
 
@@ -121,7 +123,8 @@ public class MeetupDomainService {
 
     @Transactional(readOnly = true)
     public MeetupDetail getById(UUID meetupId, UUID viewerMemberId) {
-        if (entityService.isBlockedInMeetup(meetupId, viewerMemberId)) {
+        Profile viewerProfile = profileService.getByMemberId(viewerMemberId);
+        if (entityService.isBlockedInMeetup(meetupId, viewerProfile.getId())) {
             log.info("차단 관계의 사용자가 있는 모임 조회 시도. id={}", meetupId);
             throw new NoSuchElementException("해당 Id의 모임이 존재하지 않습니다. id=" + meetupId);
         }

--- a/src/main/java/com/pnu/momeet/domain/meetup/service/MeetupEntityService.java
+++ b/src/main/java/com/pnu/momeet/domain/meetup/service/MeetupEntityService.java
@@ -69,11 +69,11 @@ public class MeetupEntityService {
             Double radius,
             MainCategory mainCategory,
             String search,
-            UUID viewerMemberId
+            UUID viewerProfileId
     ) {
         log.debug("특정 위치 기반 meetup 목록 조회 시도. location={}, radius={}", location, radius);
         var meetups = meetupRepository.findAllByDistanceAndPredicates(
-                location, radius, mainCategory, search, viewerMemberId
+                location, radius, mainCategory, search, viewerProfileId
         );
         log.debug("특정 위치 기반 meetup 목록 조회 성공. size={}", meetups.size());
         return meetups;
@@ -180,7 +180,7 @@ public class MeetupEntityService {
     }
 
     @Transactional(readOnly = true)
-    public boolean isBlockedInMeetup(UUID meetupId, UUID viewerMemberId) {
-        return meetupRepository.existsBlockedInMeetup(meetupId, viewerMemberId);
+    public boolean isBlockedInMeetup(UUID meetupId, UUID viewerProfileId) {
+        return meetupRepository.existsBlockedInMeetup(meetupId, viewerProfileId);
     }
 }

--- a/src/main/java/com/pnu/momeet/domain/participant/repository/ParticipantDslRepository.java
+++ b/src/main/java/com/pnu/momeet/domain/participant/repository/ParticipantDslRepository.java
@@ -6,5 +6,5 @@ import java.util.List;
 import java.util.UUID;
 
 public interface ParticipantDslRepository {
-    List<Participant> findAllVisibleByMeetupId(UUID meetupId, UUID viewerMemberId);
+    List<Participant> findAllVisibleByMeetupId(UUID meetupId, UUID viewerProfileId);
 }

--- a/src/main/java/com/pnu/momeet/domain/participant/repository/ParticipantDslRepositoryImpl.java
+++ b/src/main/java/com/pnu/momeet/domain/participant/repository/ParticipantDslRepositoryImpl.java
@@ -18,15 +18,15 @@ public class ParticipantDslRepositoryImpl implements ParticipantDslRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
-    public List<Participant> findAllVisibleByMeetupId(UUID meetupId, UUID viewerMemberId) {
+    public List<Participant> findAllVisibleByMeetupId(UUID meetupId, UUID viewerProfileId) {
         QParticipant p = QParticipant.participant;
         QProfile prof = QProfile.profile;
         QUserBlock ub = QUserBlock.userBlock;
 
         BooleanExpression viewerBlocksTarget =
-            ub.blockerId.eq(viewerMemberId).and(ub.blockedId.eq(prof.memberId));
+            ub.blockerProfileId.eq(viewerProfileId).and(ub.blockedProfileId.eq(prof.id));
         BooleanExpression targetBlocksViewer =
-            ub.blockerId.eq(prof.memberId).and(ub.blockedId.eq(viewerMemberId));
+            ub.blockerProfileId.eq(prof.id).and(ub.blockedProfileId.eq(viewerProfileId));
         BooleanExpression blockedEither = viewerBlocksTarget.or(targetBlocksViewer);
 
         // 상호 차단이 없는 경우만 조회

--- a/src/main/java/com/pnu/momeet/domain/participant/service/ParticipantDomainService.java
+++ b/src/main/java/com/pnu/momeet/domain/participant/service/ParticipantDomainService.java
@@ -52,6 +52,7 @@ public class ParticipantDomainService {
         UUID meetupId,
         UUID viewerMemberId
     ) {
+        Profile viewerProfile = profileService.getByMemberId(viewerMemberId);
         if (!profileService.existsByMemberId(viewerMemberId)) {
             log.info("존재하지 않는 멤버 ID로 참가자 조회 시도. memberId={}", viewerMemberId);
             throw new NoSuchElementException("해당 멤버가 존재하지 않습니다.");
@@ -61,7 +62,7 @@ public class ParticipantDomainService {
             log.info("존재하지 않는 모임 ID로 참가자 조회 시도. meetupId={}", meetupId);
             throw new NoSuchElementException("해당 모임이 존재하지 않습니다.");
         }
-        return entityService.findAllVisibleByMeetupId(meetupId, viewerMemberId)
+        return entityService.findAllVisibleByMeetupId(meetupId, viewerProfile.getId())
             .stream()
             .map(ParticipantEntityMapper::toDto)
             .toList();

--- a/src/main/java/com/pnu/momeet/domain/participant/service/ParticipantEntityService.java
+++ b/src/main/java/com/pnu/momeet/domain/participant/service/ParticipantEntityService.java
@@ -25,8 +25,8 @@ public class ParticipantEntityService {
     }
 
     @Transactional(readOnly = true)
-    public List<Participant> findAllVisibleByMeetupId(UUID meetupId, UUID viewerMemberId) {
-        return participantRepository.findAllVisibleByMeetupId(meetupId, viewerMemberId);
+    public List<Participant> findAllVisibleByMeetupId(UUID meetupId, UUID viewerProfileId) {
+        return participantRepository.findAllVisibleByMeetupId(meetupId, viewerProfileId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/pnu/momeet/domain/profile/repository/ProfileDslRepository.java
+++ b/src/main/java/com/pnu/momeet/domain/profile/repository/ProfileDslRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.domain.Pageable;
 import java.util.UUID;
 
 public interface ProfileDslRepository {
-    Page<BlockedProfileResponse> findBlockedProfiles(UUID blockerId, Pageable pageable);
+    Page<BlockedProfileResponse> findBlockedProfiles(UUID blockerProfileId, Pageable pageable);
 }

--- a/src/main/java/com/pnu/momeet/domain/profile/repository/ProfileDslRepositoryImpl.java
+++ b/src/main/java/com/pnu/momeet/domain/profile/repository/ProfileDslRepositoryImpl.java
@@ -21,7 +21,7 @@ public class ProfileDslRepositoryImpl implements ProfileDslRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Transactional(readOnly = true)
-    public Page<BlockedProfileResponse> findBlockedProfiles(UUID blockerId, Pageable pageable) {
+    public Page<BlockedProfileResponse> findBlockedProfiles(UUID blockerProfileId, Pageable pageable) {
         QUserBlock b = QUserBlock.userBlock;
         QProfile p = QProfile.profile;
 
@@ -36,8 +36,8 @@ public class ProfileDslRepositoryImpl implements ProfileDslRepository {
                 b.createdAt     // blockedAt
             ))
             .from(b)
-            .join(p).on(p.memberId.eq(b.blockedId))
-            .where(b.blockerId.eq(blockerId))
+            .join(p).on(p.id.eq(b.blockedProfileId))
+            .where(b.blockerProfileId.eq(blockerProfileId))
             .orderBy(b.createdAt.desc())
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
@@ -47,7 +47,7 @@ public class ProfileDslRepositoryImpl implements ProfileDslRepository {
         Long total = jpaQueryFactory
             .select(b.count())
             .from(b)
-            .where(b.blockerId.eq(blockerId))
+            .where(b.blockerProfileId.eq(blockerProfileId))
             .fetchOne();
 
         long totalElements = total == null ? 0L : total;

--- a/src/main/java/com/pnu/momeet/domain/profile/service/ProfileEntityService.java
+++ b/src/main/java/com/pnu/momeet/domain/profile/service/ProfileEntityService.java
@@ -58,8 +58,8 @@ public class ProfileEntityService {
     }
 
     @Transactional(readOnly = true)
-    public Page<BlockedProfileResponse> getBlockedProfiles(UUID blockerId, Pageable pageable) {
-        return profileRepository.findBlockedProfiles(blockerId, pageable);
+    public Page<BlockedProfileResponse> getBlockedProfiles(UUID blockerProfileId, Pageable pageable) {
+        return profileRepository.findBlockedProfiles(blockerProfileId, pageable);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/sql/init_scheme.sql
+++ b/src/main/resources/sql/init_scheme.sql
@@ -200,11 +200,11 @@ CREATE INDEX IF NOT EXISTS idx_profile_rep_only
 
 CREATE TABLE IF NOT EXISTS user_block (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    blocker_id UUID NOT NULL REFERENCES member(id) ON DELETE CASCADE,
-    blocked_id UUID NOT NULL REFERENCES member(id) ON DELETE CASCADE,
+    blocker_profile_id UUID NOT NULL REFERENCES profile(id) ON DELETE CASCADE,
+    blocked_profile_id UUID NOT NULL REFERENCES profile(id) ON DELETE CASCADE,
     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    CONSTRAINT uq_user_block UNIQUE (blocker_id, blocked_id),
-    CONSTRAINT ck_user_block_self CHECK (blocker_id <> blocked_id)
+    CONSTRAINT uq_user_block UNIQUE (blocker_profile_id, blocked_profile_id),
+    CONSTRAINT ck_user_block_self CHECK (blocker_profile_id <> blocked_profile_id)
 );
 
 CREATE TABLE user_report (

--- a/src/test/java/com/pnu/momeet/e2e/block/BlockCreateTest.java
+++ b/src/test/java/com/pnu/momeet/e2e/block/BlockCreateTest.java
@@ -19,7 +19,7 @@ public class BlockCreateTest extends BaseBlockTest{
         RestAssured.given()
             .header(AUTH_HEADER, BEAR_PREFIX + getToken(Role.ROLE_USER).accessToken())
             .when()
-            .delete("/{targetId}", testAdminMemberId)
+            .delete("/{targetProfileId}", testAdminProfileId)
             .then()
             .statusCode(anyOf(is(204), is(401))); // 미로그인 베이스면 204만 체크해도 OK
     }
@@ -31,12 +31,12 @@ public class BlockCreateTest extends BaseBlockTest{
             .given()
             .header(AUTH_HEADER, BEAR_PREFIX + getToken(Role.ROLE_USER).accessToken())
             .when()
-            .post("/{targetId}", testAdminMemberId) // USER가 ADMIN을 차단
+            .post("/{targetProfileId}", testAdminProfileId) // USER가 ADMIN을 차단
             .then()
             .log().all()
             .statusCode(201)
-            .body("blockedId", equalTo(testAdminMemberId.toString()))
-            .body("blockerId", equalTo(testUserMemberId.toString()))
+            .body("blockedProfileId", equalTo(testAdminProfileId.toString()))
+            .body("blockerProfileId", equalTo(testUserProfileId.toString()))
             .body("createdAt", notNullValue());
     }
 
@@ -47,7 +47,7 @@ public class BlockCreateTest extends BaseBlockTest{
             .given()
             .header(AUTH_HEADER, BEAR_PREFIX + getToken(Role.ROLE_USER).accessToken())
             .when()
-            .post("/{targetId}", testUserMemberId)
+            .post("/{targetProfileId}", testUserProfileId)
             .then()
             .log().all()
             .statusCode(400);
@@ -59,13 +59,13 @@ public class BlockCreateTest extends BaseBlockTest{
         // 선차단
         RestAssured.given()
             .header(AUTH_HEADER, BEAR_PREFIX + getToken(Role.ROLE_USER).accessToken())
-            .post("/{targetId}", testAdminMemberId)
+            .post("/{targetProfileId}", testAdminProfileId)
             .then().statusCode(201);
 
         // 동일 대상 재요청
         RestAssured.given()
             .header(AUTH_HEADER, BEAR_PREFIX + getToken(Role.ROLE_USER).accessToken())
-            .post("/{targetId}", testAdminMemberId)
+            .post("/{targetProfileId}", testAdminProfileId)
             .then()
             .log().all()
             .statusCode(409);

--- a/src/test/java/com/pnu/momeet/e2e/block/BlockDeleteTest.java
+++ b/src/test/java/com/pnu/momeet/e2e/block/BlockDeleteTest.java
@@ -14,7 +14,7 @@ public class BlockDeleteTest extends BaseBlockTest {
         RestAssured.given()
             .header(AUTH_HEADER, BEAR_PREFIX + getToken(Role.ROLE_USER).accessToken())
             .when()
-            .post("/{targetId}", testAdminMemberId)
+            .post("/{targetProfileId}", testAdminProfileId)
             .then()
             .statusCode(201);
 
@@ -22,7 +22,7 @@ public class BlockDeleteTest extends BaseBlockTest {
         RestAssured.given()
             .header(AUTH_HEADER, BEAR_PREFIX + getToken(Role.ROLE_USER).accessToken())
             .when()
-            .delete("/{targetId}", testAdminMemberId)
+            .delete("/{targetProfileId}", testAdminProfileId)
             .then()
             .statusCode(204);
     }
@@ -34,7 +34,7 @@ public class BlockDeleteTest extends BaseBlockTest {
         RestAssured.given()
             .header(AUTH_HEADER, BEAR_PREFIX + getToken(Role.ROLE_USER).accessToken())
             .when()
-            .delete("/{targetId}", testAdminMemberId)
+            .delete("/{targetProfileId}", testAdminProfileId)
             .then()
             .statusCode(204);
 
@@ -42,7 +42,7 @@ public class BlockDeleteTest extends BaseBlockTest {
         RestAssured.given()
             .header(AUTH_HEADER, BEAR_PREFIX + getToken(Role.ROLE_USER).accessToken())
             .when()
-            .delete("/{targetId}", testAdminMemberId)
+            .delete("/{targetProfileId}", testAdminProfileId)
             .then()
             .statusCode(204);
     }
@@ -52,7 +52,7 @@ public class BlockDeleteTest extends BaseBlockTest {
     void delete_unauthorized_returns401() {
         RestAssured.given()
             .when()
-            .delete("/{targetId}", testAdminMemberId)
+            .delete("/{targetProfileId}", testAdminProfileId)
             .then()
             .statusCode(401);
     }
@@ -64,7 +64,7 @@ public class BlockDeleteTest extends BaseBlockTest {
         RestAssured.given()
             .header(AUTH_HEADER, BEAR_PREFIX + getToken(Role.ROLE_ADMIN).accessToken())
             .when()
-            .post("/{targetId}", testUserMemberId)
+            .post("/{targetProfileId}", testUserProfileId)
             .then()
             .statusCode(201);
 
@@ -72,7 +72,7 @@ public class BlockDeleteTest extends BaseBlockTest {
         RestAssured.given()
             .header(AUTH_HEADER, BEAR_PREFIX + getToken(Role.ROLE_USER).accessToken())
             .when()
-            .delete("/{targetId}", testAdminMemberId)
+            .delete("/{targetProfileId}", testAdminProfileId)
             .then()
             .statusCode(204);
     }

--- a/src/test/java/com/pnu/momeet/e2e/block/BlockGetTest.java
+++ b/src/test/java/com/pnu/momeet/e2e/block/BlockGetTest.java
@@ -21,7 +21,7 @@ public class BlockGetTest extends BaseBlockTest {
         // 테스트 간 상태 격리: USER→ADMIN 차단 관계 초기화(idempotent 204)
         given()
             .header(AUTH_HEADER, BEAR_PREFIX + getToken(Role.ROLE_USER).accessToken())
-            .when().delete("/{targetId}", testAdminMemberId)
+            .when().delete("/{targetProfileId}", testAdminProfileId)
             .then().statusCode(204);
     }
 
@@ -32,7 +32,7 @@ public class BlockGetTest extends BaseBlockTest {
         // 여기선 ADMIN만 차단 후 목록에 최소 1건 존재 확인
         given()
             .header(AUTH_HEADER, BEAR_PREFIX + getToken(Role.ROLE_USER).accessToken())
-            .when().post("/{targetId}", testAdminMemberId)
+            .when().post("/{targetProfileId}", testAdminProfileId)
             .then().statusCode(201);
 
         given()

--- a/src/test/java/com/pnu/momeet/e2e/meetup/BaseMeetupTest.java
+++ b/src/test/java/com/pnu/momeet/e2e/meetup/BaseMeetupTest.java
@@ -81,9 +81,9 @@ public abstract class BaseMeetupTest extends BaseE2ETest {
         return base.plusMinutes(30L * k).format(REQUEST_FORMAT);
     }
 
-    protected void blockIfNeeded(UUID blockerId, UUID blockedId) {
+    protected void blockIfNeeded(UUID blockerMemberId, UUID blockedProfileId) {
         try {
-            blockService.createUserBlock(blockerId, blockedId);
+            blockService.createUserBlock(blockerMemberId, blockedProfileId);
         } catch (IllegalStateException e) {
             // 서비스에서 "이미 차단한 사용자입니다."로 던지는 경우 허용
             if (!e.getMessage().contains("이미 차단한 사용자")) throw e;

--- a/src/test/java/com/pnu/momeet/e2e/meetup/MeetupReadTest.java
+++ b/src/test/java/com/pnu/momeet/e2e/meetup/MeetupReadTest.java
@@ -209,9 +209,9 @@ class MeetupReadTest extends BaseMeetupTest {
     @Test
     @DisplayName("[차단] viewer가 모임 소유자를 차단하면 상세는 404")
     void get_meetup_by_id_blocked_by_viewer_404() {
-        // given: BOB이 모임을 만들고, ALICE가 BOB을 차단
+        // given: BOB이 모임을 만들고, ALICE가 CHRIS을 차단
         UUID meetupId = createTestMeetupByEmail(CHRIS_EMAIL);
-        blockIfNeeded(users.get(ALICE_EMAIL).id(), users.get(CHRIS_EMAIL).id()); // ALICE → BOB
+        blockIfNeeded(users.get(ALICE_EMAIL).id(), userProfiles.get(CHRIS_EMAIL).getId()); // ALICE → CHRIS
 
         // when & then: ALICE로 상세 조회 시 404
         RestAssured.given()
@@ -227,7 +227,7 @@ class MeetupReadTest extends BaseMeetupTest {
     @DisplayName("[차단] 모임 소유자가 viewer를 차단해도 상세는 404")
     void get_meetup_by_id_blocked_by_owner_404() {
         UUID meetupId = createTestMeetupByEmail(CHRIS_EMAIL);
-        blockIfNeeded(users.get(CHRIS_EMAIL).id(), users.get(ALICE_EMAIL).id()); // BOB → ALICE
+        blockIfNeeded(users.get(CHRIS_EMAIL).id(), userProfiles.get(ALICE_EMAIL).getId()); // CHRIS → ALICE
 
         RestAssured.given()
             .header(AUTH_HEADER, BEAR_PREFIX + userTokens.get(ALICE_EMAIL).accessToken())
@@ -242,7 +242,7 @@ class MeetupReadTest extends BaseMeetupTest {
     @DisplayName("[차단] 페이지 조회 시 차단 모임은 목록에서 제외된다")
     void get_meetup_page_excludes_blocked_meetup() {
         UUID meetupId = createTestMeetupByEmail(CHRIS_EMAIL);
-        blockIfNeeded(users.get(ALICE_EMAIL).id(), users.get(CHRIS_EMAIL).id()); // ALICE → BOB
+        blockIfNeeded(users.get(ALICE_EMAIL).id(), userProfiles.get(CHRIS_EMAIL).getId()); // ALICE → CHRIS
 
         RestAssured.given()
             .header(AUTH_HEADER, BEAR_PREFIX + userTokens.get(ALICE_EMAIL).accessToken())
@@ -264,8 +264,8 @@ class MeetupReadTest extends BaseMeetupTest {
         // given: 모임은 BOB이 만듦(= owner=BOB)
         UUID meetupId = createTestMeetupByEmail(CHRIS_EMAIL);
 
-        // ALICE -> BOB 차단
-        blockIfNeeded(users.get(ALICE_EMAIL).id(), users.get(CHRIS_EMAIL).id());
+        // ALICE -> CHRIS 차단
+        blockIfNeeded(users.get(ALICE_EMAIL).id(), userProfiles.get(CHRIS_EMAIL).getId());
 
         // when & then: ALICE로 조회 시 해당 모임이 결과에 없어야 함
         RestAssured.given()
@@ -297,8 +297,8 @@ class MeetupReadTest extends BaseMeetupTest {
             .then()
             .statusCode(200);
 
-        // ALICE -> BOB 차단
-        blockIfNeeded(users.get(ALICE_EMAIL).id(), users.get(CHRIS_EMAIL).id());
+        // ALICE -> CHRIS 차단
+        blockIfNeeded(users.get(ALICE_EMAIL).id(), userProfiles.get(CHRIS_EMAIL).getId());
 
         // when & then: ALICE로 조회 시 해당 모임이 결과에 없어야 함
         RestAssured.given()

--- a/src/test/java/com/pnu/momeet/e2e/participant/ParticipantKickTest.java
+++ b/src/test/java/com/pnu/momeet/e2e/participant/ParticipantKickTest.java
@@ -326,7 +326,7 @@ public class ParticipantKickTest extends BaseParticipantTest {
     }
 
     @Test
-    @DisplayName("강퇴된 참가자 재참가 불가능 - 200 OK")
+    @DisplayName("강퇴된 참가자 재참가 불가능 - 403 Forbidden")
     void kickParticipant_rejoinAfterKick_fail() {
         // Given: 밋업 생성, 사용자 참가 및 강퇴
         MeetupDetail meetup = createTestMeetup(0);

--- a/src/test/java/com/pnu/momeet/e2e/participant/ParticipantKickTest.java
+++ b/src/test/java/com/pnu/momeet/e2e/participant/ParticipantKickTest.java
@@ -326,8 +326,8 @@ public class ParticipantKickTest extends BaseParticipantTest {
     }
 
     @Test
-    @DisplayName("강퇴된 참가자 재참가 가능 - 200 OK")
-    void kickParticipant_rejoinAfterKick_success() {
+    @DisplayName("강퇴된 참가자 재참가 불가능 - 200 OK")
+    void kickParticipant_rejoinAfterKick_fail() {
         // Given: 밋업 생성, 사용자 참가 및 강퇴
         MeetupDetail meetup = createTestMeetup(0);
         
@@ -362,9 +362,9 @@ public class ParticipantKickTest extends BaseParticipantTest {
                 .post("/{meetupId}/participants")
         .then()
                 .log().all()
-                .statusCode(200)
-                .body("profile.nickname", equalTo(profiles.get(1).getNickname()))
-                .body("role", equalTo("MEMBER"));
+                .statusCode(403)
+                .body("profile.nickname", nullValue())
+                .body("role", nullValue());
     }
 
     @Test

--- a/src/test/java/com/pnu/momeet/e2e/participant/ParticipantVisibleListTest.java
+++ b/src/test/java/com/pnu/momeet/e2e/participant/ParticipantVisibleListTest.java
@@ -71,7 +71,7 @@ public class ParticipantVisibleListTest extends BaseParticipantTest {
             .statusCode(200);
 
         // viewer(0) -> target(1) 차단 생성
-        blockRepository.save(UserBlock.create(members.get(0).id(), members.get(1).id()));
+        blockRepository.save(UserBlock.create(profiles.get(0).getId(), profiles.get(1).getId()));
 
         // host(0) 기준 visible 조회 → 1번은 제외, 0/2만 보임
         given()
@@ -103,7 +103,7 @@ public class ParticipantVisibleListTest extends BaseParticipantTest {
             .statusCode(200);
 
         // target(1) -> viewer(0) 역방향 차단
-        blockRepository.save(UserBlock.create(members.get(1).id(), members.get(0).id()));
+        blockRepository.save(UserBlock.create(profiles.get(1).getId(), profiles.get(0).getId()));
 
         // host(0) 기준 visible 조회 → 1번은 제외, host만 보임
         given()
@@ -134,7 +134,7 @@ public class ParticipantVisibleListTest extends BaseParticipantTest {
         }
 
         // viewer(2) -> target(host=0) 차단
-        blockRepository.save(UserBlock.create(members.get(2).id(), members.get(0).id()));
+        blockRepository.save(UserBlock.create(profiles.get(2).getId(), profiles.get(0).getId()));
 
         // 2번 시점에서 visible 조회 → host(0) 제외, 1/2만 보임
         given()

--- a/src/test/java/com/pnu/momeet/unit/block/BlockDomainServiceTest.java
+++ b/src/test/java/com/pnu/momeet/unit/block/BlockDomainServiceTest.java
@@ -7,6 +7,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import com.pnu.momeet.domain.block.dto.request.BlockPageRequest;
 import com.pnu.momeet.domain.block.dto.response.BlockResponse;
@@ -15,7 +17,9 @@ import com.pnu.momeet.domain.block.service.BlockDomainService;
 import com.pnu.momeet.domain.block.service.BlockEntityService;
 import com.pnu.momeet.domain.member.service.MemberEntityService;
 import com.pnu.momeet.domain.profile.dto.response.BlockedProfileResponse;
+import com.pnu.momeet.domain.profile.entity.Profile;
 import com.pnu.momeet.domain.profile.service.ProfileEntityService;
+import java.lang.reflect.Constructor;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -26,146 +30,155 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class BlockDomainServiceTest {
 
-    @Mock
-    private BlockEntityService entityService;
-    @Mock private MemberEntityService memberService;
+    @Mock private BlockEntityService entityService;
     @Mock private ProfileEntityService profileService;
+    @InjectMocks private BlockDomainService domainService;
 
-    @InjectMocks
-    private BlockDomainService domainService;
-
-    @Test
-    @DisplayName("createUserBlock: 정상 생성 → BlockResponse 반환")
-    void createUserBlock_success() {
-        UUID me = UUID.randomUUID();
-        UUID target = UUID.randomUUID();
-
-        given(memberService.existsById(target)).willReturn(true);
-        given(entityService.exists(me, target)).willReturn(false);
-
-        // save가 반환할 엔티티에 createdAt까지 세팅
-        var block = UserBlock.create(me, target);
-        // BaseCreatedEntity의 createdAt을 흉내내 세팅
-        org.springframework.test.util.ReflectionTestUtils
-            .setField(block, "createdAt", LocalDateTime.now());
-        given(entityService.save(me, target)).willReturn(block);
-
-        BlockResponse resp = domainService.createUserBlock(me, target);
-
-        assertThat(resp.blockerId()).isEqualTo(me);
-        assertThat(resp.blockedId()).isEqualTo(target);
-        assertThat(resp.createdAt()).isNotNull();
-        verify(entityService).save(me, target);
+    // 프로필 더미 생성 헬퍼
+    private static Profile profileWithId(UUID id) {
+        try {
+            Constructor<Profile> ctor = Profile.class.getDeclaredConstructor();
+            ctor.setAccessible(true);                  // protected 생성자 우회
+            Profile p = ctor.newInstance();
+            ReflectionTestUtils.setField(p, "id", id); // BaseEntity.id 직접 주입
+            return p;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
-    @Test
-    @DisplayName("createUserBlock: 대상 회원 없음 → NoSuchElementException")
+    @Test @DisplayName("createUserBlock: 정상 생성 → BlockResponse 반환")
+    void createUserBlock_success() {
+        UUID meMember = UUID.randomUUID();
+        UUID myProfile = UUID.randomUUID();
+        UUID targetProfile = UUID.randomUUID();
+
+        given(profileService.getByMemberId(meMember)).willReturn(profileWithId(myProfile));
+        given(profileService.existsById(targetProfile)).willReturn(true);
+        given(entityService.exists(myProfile, targetProfile)).willReturn(false);
+
+        var block = com.pnu.momeet.domain.block.entity.UserBlock.create(myProfile, targetProfile);
+        ReflectionTestUtils.setField(block, "createdAt", LocalDateTime.now());
+        given(entityService.save(myProfile, targetProfile)).willReturn(block);
+
+        BlockResponse resp = domainService.createUserBlock(meMember, targetProfile);
+
+        assertThat(resp.blockerProfileId()).isEqualTo(myProfile);
+        assertThat(resp.blockedProfileId()).isEqualTo(targetProfile);
+        assertThat(resp.createdAt()).isNotNull();
+        verify(entityService).save(myProfile, targetProfile);
+    }
+
+    @Test @DisplayName("createUserBlock: 대상 프로필 없음 → NoSuchElementException")
     void createUserBlock_targetNotFound() {
-        UUID me = UUID.randomUUID();
-        UUID target = UUID.randomUUID();
+        UUID meMember = UUID.randomUUID();
+        UUID myProfile = UUID.randomUUID();
+        UUID targetProfile = UUID.randomUUID();
 
-        given(memberService.existsById(target)).willReturn(false);
+        given(profileService.getByMemberId(meMember)).willReturn(profileWithId(myProfile));
+        given(profileService.existsById(targetProfile)).willReturn(false);
 
-        assertThatThrownBy(() -> domainService.createUserBlock(me, target))
+        assertThatThrownBy(() -> domainService.createUserBlock(meMember, targetProfile))
             .isInstanceOf(NoSuchElementException.class)
-            .hasMessageContaining("대상 사용자를 찾을 수 없습니다.");
+            .hasMessageContaining("대상 사용자 프로필을 찾을 수 없습니다.");
 
         verify(entityService, never()).save(any(), any());
     }
 
-    @Test
-    @DisplayName("createUserBlock: 자기 자신 차단 → IllegalArgumentException")
+    @Test @DisplayName("createUserBlock: 자기 자신 차단 → IllegalArgumentException")
     void createUserBlock_selfBlock() {
-        UUID me = UUID.randomUUID();
+        UUID meMember = UUID.randomUUID();
+        UUID myProfile = UUID.randomUUID();
 
-        assertThatThrownBy(() -> domainService.createUserBlock(me, me))
+        given(profileService.getByMemberId(meMember)).willReturn(profileWithId(myProfile));
+
+        assertThatThrownBy(() -> domainService.createUserBlock(meMember, myProfile))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("자기 자신은 차단할 수 없습니다.");
 
         verify(entityService, never()).save(any(), any());
     }
 
-    @Test
-    @DisplayName("createUserBlock: 이미 차단됨 → IllegalStateException")
+    @Test @DisplayName("createUserBlock: 이미 차단됨 → IllegalStateException")
     void createUserBlock_duplicate() {
-        UUID me = UUID.randomUUID();
-        UUID target = UUID.randomUUID();
+        UUID meMember = UUID.randomUUID();
+        UUID myProfile = UUID.randomUUID();
+        UUID targetProfile = UUID.randomUUID();
 
-        given(memberService.existsById(target)).willReturn(true);
-        given(entityService.exists(me, target)).willReturn(true);
+        given(profileService.getByMemberId(meMember)).willReturn(profileWithId(myProfile));
+        given(profileService.existsById(targetProfile)).willReturn(true);
+        given(entityService.exists(myProfile, targetProfile)).willReturn(true);
 
-        assertThatThrownBy(() -> domainService.createUserBlock(me, target))
+        assertThatThrownBy(() -> domainService.createUserBlock(meMember, targetProfile))
             .isInstanceOf(IllegalStateException.class)
-            .hasMessageContaining("이미 차단한 사용자입니다.");
+            .hasMessageContaining("이미 차단한 사용자 프로필입니다.");
 
         verify(entityService, never()).save(any(), any());
     }
 
-    @Test
-    @DisplayName("createUserBlock: 동시성으로 UNIQUE 위반 → ResponseStatusException(409)")
+    @Test @DisplayName("createUserBlock: 동시성 UNIQUE 위반 → DataIntegrityViolationException 전파")
     void createUserBlock_raceConflict() {
-        UUID me = UUID.randomUUID();
-        UUID target = UUID.randomUUID();
+        UUID meMember = UUID.randomUUID();
+        UUID myProfile = UUID.randomUUID();
+        UUID targetProfile = UUID.randomUUID();
 
-        given(memberService.existsById(target)).willReturn(true);
-        given(entityService.exists(me, target)).willReturn(false);
-        given(entityService.save(me, target))
+        given(profileService.getByMemberId(meMember)).willReturn(profileWithId(myProfile));
+        given(profileService.existsById(targetProfile)).willReturn(true);
+        given(entityService.exists(myProfile, targetProfile)).willReturn(false);
+        given(entityService.save(myProfile, targetProfile))
             .willThrow(new DataIntegrityViolationException("duplicate key"));
 
-        assertThatThrownBy(() -> domainService.createUserBlock(me, target))
-            .isInstanceOf(org.springframework.web.server.ResponseStatusException.class)
-            .extracting("statusCode").asString().contains("409");
+        assertThatThrownBy(() -> domainService.createUserBlock(meMember, targetProfile))
+            .isInstanceOf(DataIntegrityViolationException.class);
     }
 
-    @Test
-    @DisplayName("deleteBlock: 항상 위임(idempotent)")
+    @Test @DisplayName("deleteBlock: 항상 위임(idempotent)")
     void deleteBlock_alwaysDelegates() {
-        UUID me = UUID.randomUUID();
-        UUID target = UUID.randomUUID();
+        UUID meMember = UUID.randomUUID();
+        UUID myProfile = UUID.randomUUID();
+        UUID targetProfile = UUID.randomUUID();
 
-        given(entityService.delete(me, target)).willReturn(1L);
+        given(profileService.getByMemberId(meMember)).willReturn(profileWithId(myProfile));
+        given(entityService.delete(myProfile, targetProfile)).willReturn(1L);
 
-        domainService.deleteBlock(me, target);
+        domainService.deleteBlock(meMember, targetProfile);
 
-        verify(entityService).delete(me, target);
+        verify(entityService).delete(myProfile, targetProfile);
     }
 
-    @Test
-    @DisplayName("getMyBlockedProfiles: ProfileEntityService에 Pageable 전달 & 결과 반환")
+    @Test @DisplayName("getMyBlockedProfiles: ProfileEntityService에 (내 profileId, Pageable) 전달")
     void getMyBlockedProfiles_delegatesToProfileService() {
-        UUID me = UUID.randomUUID();
+        UUID meMember = UUID.randomUUID();
+        UUID myProfile = UUID.randomUUID();
 
-        // 요청 DTO
-        BlockPageRequest req = new BlockPageRequest();
-        req.setPage(0);
-        req.setSize(20);
+        var req = new BlockPageRequest();
+        req.setPage(0); req.setSize(20);
 
-        // Stub Page
-        Pageable pageable = PageRequest.of(0, 20);
+        var pageable = PageRequest.of(0, 20);
         var row = new BlockedProfileResponse(
             UUID.randomUUID(), "닉", null, null, LocalDateTime.now()
         );
-        Page<BlockedProfileResponse> stub = new PageImpl<>(List.of(row), pageable, 1);
+        var stub = new PageImpl<>(List.of(row), pageable, 1);
 
-        ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
-        given(profileService.getBlockedProfiles(eq(me), any(Pageable.class))).willReturn(stub);
+        given(profileService.getByMemberId(meMember)).willReturn(profileWithId(myProfile));
+        given(profileService.getBlockedProfiles(eq(myProfile), any(Pageable.class)))
+            .willReturn(stub);
 
-        Page<BlockedProfileResponse> out = domainService.getMyBlockedProfiles(me, req);
+        var out = domainService.getMyBlockedProfiles(meMember, req);
 
         assertThat(out.getTotalElements()).isEqualTo(1);
-        verify(profileService).getBlockedProfiles(eq(me), captor.capture());
-        Pageable used = captor.getValue();
-        assertThat(used.getPageNumber()).isEqualTo(0);
-        assertThat(used.getPageSize()).isEqualTo(20); // 현재 mapper는 size 상한 없이 그대로 사용
+        verify(profileService).getBlockedProfiles(eq(myProfile), any(Pageable.class));
     }
 }

--- a/src/test/java/com/pnu/momeet/unit/block/BlockEntityServiceTest.java
+++ b/src/test/java/com/pnu/momeet/unit/block/BlockEntityServiceTest.java
@@ -29,12 +29,12 @@ class BlockEntityServiceTest {
     @DisplayName("exists: 레포지토리 위임")
     void exists_delegatesToRepository() {
         UUID a = UUID.randomUUID(), b = UUID.randomUUID();
-        given(blockRepository.existsByBlockerIdAndBlockedId(a, b)).willReturn(true);
+        given(blockRepository.existsByBlockerProfileIdAndBlockedProfileId(a, b)).willReturn(true);
 
         boolean exists = entityService.exists(a, b);
 
         assertThat(exists).isTrue();
-        verify(blockRepository).existsByBlockerIdAndBlockedId(a, b);
+        verify(blockRepository).existsByBlockerProfileIdAndBlockedProfileId(a, b);
     }
 
     @Test
@@ -48,8 +48,8 @@ class BlockEntityServiceTest {
 
         UserBlock saved = entityService.save(a, b);
 
-        assertThat(saved.getBlockerId()).isEqualTo(a);
-        assertThat(saved.getBlockedId()).isEqualTo(b);
+        assertThat(saved.getBlockerProfileId()).isEqualTo(a);
+        assertThat(saved.getBlockedProfileId()).isEqualTo(b);
         verify(blockRepository).save(any(UserBlock.class));
     }
 
@@ -57,11 +57,11 @@ class BlockEntityServiceTest {
     @DisplayName("delete: (blockerId, blockedId) 조건 삭제 위임")
     void delete_delegatesToRepository() {
         UUID a = UUID.randomUUID(), b = UUID.randomUUID();
-        given(blockRepository.deleteByBlockerIdAndBlockedId(a, b)).willReturn(1L);
+        given(blockRepository.deleteByBlockerProfileIdAndBlockedProfileId(a, b)).willReturn(1L);
 
         long deleted = entityService.delete(a, b);
 
         assertThat(deleted).isEqualTo(1L);
-        verify(blockRepository).deleteByBlockerIdAndBlockedId(a, b);
+        verify(blockRepository).deleteByBlockerProfileIdAndBlockedProfileId(a, b);
     }
 }

--- a/src/test/java/com/pnu/momeet/unit/meetup/MeetupDomainServiceTest.java
+++ b/src/test/java/com/pnu/momeet/unit/meetup/MeetupDomainServiceTest.java
@@ -9,6 +9,9 @@ import com.pnu.momeet.domain.meetup.entity.Meetup;
 import com.pnu.momeet.domain.meetup.service.MeetupDomainService;
 import com.pnu.momeet.domain.meetup.service.MeetupEntityService;
 import com.pnu.momeet.domain.meetup.service.mapper.MeetupEntityMapper;
+import com.pnu.momeet.domain.profile.entity.Profile;
+import com.pnu.momeet.domain.profile.service.ProfileEntityService;
+import java.lang.reflect.Constructor;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,6 +24,7 @@ import org.springframework.data.domain.*;
 
 import java.util.NoSuchElementException;
 import java.util.UUID;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -36,12 +40,31 @@ class MeetupDomainServiceTest {
     @Mock
     private MeetupEntityService meetupEntityService;
 
+    @Mock
+    private ProfileEntityService profileService;
+
+    private static Profile profileWithId(UUID id) {
+        try {
+            Constructor<Profile> ctor = Profile.class.getDeclaredConstructor();
+            ctor.setAccessible(true);
+            Profile p = ctor.newInstance();
+            ReflectionTestUtils.setField(p, "id", id);
+            return p;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Test
     @DisplayName("페이지 조회: DB에서 필터된 결과를 사용하므로 content/total이 일치(빈 페이지)")
     void getAllBySpecification_returnsEmptyPage_consistentTotals() {
         // given
-        UUID viewer = UUID.randomUUID();
+        UUID viewerMemberId = UUID.randomUUID();
+        UUID viewerProfileId = UUID.randomUUID();
         MeetupPageRequest req = new MeetupPageRequest();
+
+        when(profileService.getByMemberId(viewerMemberId))
+            .thenReturn(profileWithId(viewerProfileId));
 
         Page<Meetup> repoPage =
             new PageImpl<>(java.util.Collections.emptyList(),
@@ -54,7 +77,7 @@ class MeetupDomainServiceTest {
 
         // when
         Page<MeetupResponse> result =
-            meetupDomainService.getAllBySpecification(req, viewer);
+            meetupDomainService.getAllBySpecification(req, viewerMemberId);
 
         // then
         verify(meetupEntityService, times(1)).getAllBySpecificationWithPagination(
@@ -72,12 +95,16 @@ class MeetupDomainServiceTest {
     void getById_blocked_then404() {
         // given
         UUID meetupId = UUID.randomUUID();
-        UUID viewer = UUID.randomUUID();
+        UUID viewerMemberId = UUID.randomUUID();
+        UUID viewerProfileId = UUID.randomUUID();
 
-        when(meetupEntityService.isBlockedInMeetup(meetupId, viewer)).thenReturn(true);
+        when(profileService.getByMemberId(viewerMemberId))
+            .thenReturn(profileWithId(viewerProfileId));
+
+        when(meetupEntityService.isBlockedInMeetup(meetupId, viewerProfileId)).thenReturn(true);
 
         // when & then
-        assertThatThrownBy(() -> meetupDomainService.getById(meetupId, viewer))
+        assertThatThrownBy(() -> meetupDomainService.getById(meetupId, viewerMemberId))
             .isInstanceOf(NoSuchElementException.class);
 
         verify(meetupEntityService, never()).getByIdWithDetails(any());
@@ -88,9 +115,13 @@ class MeetupDomainServiceTest {
     void getById_notBlocked_thenDelegates() {
         // given
         UUID meetupId = UUID.randomUUID();
-        UUID viewer = UUID.randomUUID();
+        UUID viewerMemberId = UUID.randomUUID();
+        UUID viewerProfileId = UUID.randomUUID();
 
-        when(meetupEntityService.isBlockedInMeetup(meetupId, viewer)).thenReturn(false);
+        when(profileService.getByMemberId(viewerMemberId))
+            .thenReturn(profileWithId(viewerProfileId));
+
+        when(meetupEntityService.isBlockedInMeetup(meetupId, viewerProfileId)).thenReturn(false);
         Meetup entity = mock(Meetup.class);
         when(meetupEntityService.getByIdWithDetails(meetupId)).thenReturn(entity);
 
@@ -99,7 +130,7 @@ class MeetupDomainServiceTest {
                 .thenReturn(mock(MeetupDetail.class));
 
             // when
-            MeetupDetail detail = meetupDomainService.getById(meetupId, viewer);
+            MeetupDetail detail = meetupDomainService.getById(meetupId, viewerMemberId);
 
             // then
             verify(meetupEntityService, times(1)).getByIdWithDetails(meetupId);

--- a/src/test/resources/sql/test_init_scheme.sql
+++ b/src/test/resources/sql/test_init_scheme.sql
@@ -188,15 +188,12 @@ CREATE INDEX IF NOT EXISTS idx_profile_rep_only
 
 CREATE TABLE IF NOT EXISTS public_test.user_block (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    blocker_id UUID NOT NULL REFERENCES public_test.member(id) ON DELETE CASCADE,
-    blocked_id UUID NOT NULL REFERENCES public_test.member(id) ON DELETE CASCADE,
+    blocker_profile_id UUID NOT NULL REFERENCES public_test.profile(id) ON DELETE CASCADE,
+    blocked_profile_id UUID NOT NULL REFERENCES public_test.profile(id) ON DELETE CASCADE,
     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    CONSTRAINT uq_user_block UNIQUE (blocker_id, blocked_id),
-    CONSTRAINT ck_user_block_self CHECK (blocker_id <> blocked_id)
+    CONSTRAINT uq_user_block UNIQUE (blocker_profile_id, blocked_profile_id),
+    CONSTRAINT ck_user_block_self CHECK (blocker_profile_id <> blocked_profile_id)
 );
-
-CREATE INDEX IF NOT EXISTS idx_user_block_blocker ON public_test.user_block (blocker_id);
-CREATE INDEX IF NOT EXISTS idx_user_block_blocked ON public_test.user_block (blocked_id);
 
 CREATE TABLE public_test.user_report (
     id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),


### PR DESCRIPTION
# Pull Request 템플릿

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 걸어주세요 -->
- Closes #(119)

## 💡 변경 이유
<!-- 왜 이 코드 변경이 필요했나요? 어떤 문제를 해결하거나 어떤 기능을 추가했나요? -->

차단 로직의 기준을 memberId → **profileId**로 전환해 FE(모임/프로필 UI)와 백엔드 도메인 축을 일치

## 📋 주요 변경사항
<!-- 구체적으로 어떤 것들이 변경되었는지 간단히 나열해주세요 -->
- UserBlock 엔티티를 blocker_profile_id, blocked_profile_id 기준으로 변경
- BlockRepository
  - `existsByBlockerProfileIdAndBlockedProfileId(...)` / `deleteByBlockerProfileIdAndBlockedProfileId(...)`로 전환
- BlockDomainService
  - 서비스 입력은 기존 흐름 유지(내 memberId → 내 profileId 매핑), 저장/삭제/조회는 profileId 기준으로 일관 처리
- API/스펙(호환)
  - 엔드포인트 경로/구조는 유지, 파라미터·응답만 profileId 명세로 고정
    - POST /api/blocks/{targetProfileId}
    - DELETE /api/blocks/{targetProfileId}
    - GET /api/blocks/profiles?page=...&size=...
  - 응답 필드: blockerProfileId, blockedProfileId, createdAt

## ⚠️ 발견된 위험이나 장애
<!-- 개발 중 발견된 문제점이나 주의할 부분이 있다면 작성해주세요 (없으면  삭제) -->

캐시/조회 경로: 차단 체크가 포함된 경로에서 캐시 사용 시 키를 profileId로 교체 여부 확인

## 👀 리뷰 포인트
<!-- 리뷰어가 특별히 집중해서 봐야 할 부분을 알려주세요 -->
- BlockDomainService가 memberId → profileId 변환 이후 일관되게 profileId로만 동작하는지
- 

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 (없으면 삭제해도 됩니다) -->


## ✅ 테스트 완료 사항
<!-- 어떻게 테스트했는지 간단히 작성해주세요 -->
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
- [x] (기타 테스트 내용)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Participants can no longer rejoin a meetup after being kicked.

* **Refactor**
  * Block/unblock endpoints now use profile-based path parameter (targetProfileId).
  * Block API response fields renamed to blockerProfileId and blockedProfileId.
  * Participant and meetup visibility logic updated to rely on profile-based blocking relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->