### PR TITLE
Feature/123 handle member withdraw

### DIFF
--- a/src/main/java/com/pnu/momeet/domain/meetup/entity/Meetup.java
+++ b/src/main/java/com/pnu/momeet/domain/meetup/entity/Meetup.java
@@ -9,6 +9,8 @@ import com.pnu.momeet.domain.profile.entity.Profile;
 import com.pnu.momeet.domain.sigungu.entity.Sigungu;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.locationtech.jts.geom.Point;
 
 import java.time.LocalDateTime;
@@ -24,7 +26,8 @@ import java.util.Objects;
 public class Meetup extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "owner_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.SET_NULL)
+    @JoinColumn(name = "owner_id")
     private Profile owner;
 
     @Column(name = "name", nullable = false, length = 60)

--- a/src/main/java/com/pnu/momeet/domain/meetup/repository/MeetupDslRepository.java
+++ b/src/main/java/com/pnu/momeet/domain/meetup/repository/MeetupDslRepository.java
@@ -24,7 +24,9 @@ public interface MeetupDslRepository {
 
     List<Meetup> findAllByOwnerIdAndStatusIn(UUID profileId, List<MeetupStatus> statuses);
 
-    Optional<Meetup> findParticipatedMeetupsByProfileId(UUID profileId);
+    List<Meetup> findAllParticipatedMeetupsByProfileId(UUID profileId);
+
+    Optional<Meetup> findParticipatedActiveMeetupsByProfileId(UUID profileId);
 
 
     boolean existsParticipatedMeetupByProfileId(UUID profileId);

--- a/src/main/java/com/pnu/momeet/domain/meetup/repository/MeetupDslRepositoryImpl.java
+++ b/src/main/java/com/pnu/momeet/domain/meetup/repository/MeetupDslRepositoryImpl.java
@@ -110,7 +110,20 @@ public class MeetupDslRepositoryImpl implements MeetupDslRepository {
                 .fetch();
     }
 
-    public Optional<Meetup> findParticipatedMeetupsByProfileId(UUID profileId) {
+    public List<Meetup> findAllParticipatedMeetupsByProfileId(UUID profileId) {
+        QMeetup meetup = QMeetup.meetup;
+        QParticipant participant = QParticipant.participant;
+        return jpaQueryFactory
+                .select(meetup)
+                .from(meetup)
+                .join(meetup.participants, participant)
+                .where(
+                    participant.profile.id.eq(profileId)
+                )
+                .fetch();
+    }
+
+    public Optional<Meetup> findParticipatedActiveMeetupsByProfileId(UUID profileId) {
         QMeetup meetup = QMeetup.meetup;
         QParticipant participant = QParticipant.participant;
 

--- a/src/main/java/com/pnu/momeet/domain/meetup/service/MeetupDomainService.java
+++ b/src/main/java/com/pnu/momeet/domain/meetup/service/MeetupDomainService.java
@@ -132,7 +132,7 @@ public class MeetupDomainService {
     @Transactional(readOnly = true)
     public MeetupDetail getOwnedActiveMeetupByMemberID(UUID memberId) {
         UUID profileId = profileService.mapToProfileId(memberId);
-        Meetup activeMeetups = entityService.getParticipatedMeetupByProfileId(profileId);
+        Meetup activeMeetups = entityService.getParticipatedActiveMeetupByProfileId(profileId);
         return MeetupEntityMapper.toDetail(activeMeetups);
     }
 

--- a/src/main/java/com/pnu/momeet/domain/meetup/service/MeetupEntityService.java
+++ b/src/main/java/com/pnu/momeet/domain/meetup/service/MeetupEntityService.java
@@ -87,11 +87,18 @@ public class MeetupEntityService {
         return meetups;
     }
 
+    @Transactional(readOnly = true)
+    public List<Meetup> getAllParticipatedMeetupsByProfileId(UUID profileId) {
+        log.debug("특정 프로필 ID가 참여한 meetup 목록 조회 시도. profileId={}", profileId);
+        var meetups = meetupRepository.findAllParticipatedMeetupsByProfileId(profileId);
+        log.debug("특정 프로필 ID가 참여한 meetup 목록 조회 성공. profileId={}, size={}", profileId, meetups.size());
+        return meetups;
+    }
 
     @Transactional(readOnly = true)
-    public Meetup getParticipatedMeetupByProfileId(UUID profileId) {
+    public Meetup getParticipatedActiveMeetupByProfileId(UUID profileId) {
         log.debug("특정 프로필 ID가 참여한 meetup 조회 시도. profileId={}", profileId);
-        var meetup = meetupRepository.findParticipatedMeetupsByProfileId(profileId);
+        var meetup = meetupRepository.findParticipatedActiveMeetupsByProfileId(profileId);
         if (meetup.isEmpty()) {
             log.info("특정 프로필 ID가 참여한 meetup이 없음. profileId={}", profileId);
             throw new NoSuchElementException("참여한 모임이 없습니다.");

--- a/src/main/java/com/pnu/momeet/domain/meetup/service/mapper/MeetupEntityMapper.java
+++ b/src/main/java/com/pnu/momeet/domain/meetup/service/mapper/MeetupEntityMapper.java
@@ -13,9 +13,11 @@ import com.pnu.momeet.domain.meetup.event.MeetupStartEvent;
 import com.pnu.momeet.domain.member.enums.Role;
 import com.pnu.momeet.domain.participant.entity.Participant;
 import com.pnu.momeet.domain.participant.enums.MeetupRole;
+import com.pnu.momeet.domain.profile.dto.response.ProfileResponse;
 import com.pnu.momeet.domain.profile.service.mapper.ProfileEntityMapper;
 import com.pnu.momeet.domain.sigungu.service.mapper.SigunguEntityMapper;
 import java.util.List;
+import java.util.UUID;
 
 public class
 MeetupEntityMapper {
@@ -35,10 +37,11 @@ MeetupEntityMapper {
         List<String> hashTags = meetup.getHashTags().stream()
                 .map(MeetupHashTag::getName)
                 .toList();
+        UUID ownerId = meetup.getOwner() != null ? meetup.getOwner().getId() : null;
 
         return new MeetupResponse(
                 meetup.getId(),
-                meetup.getOwner().getId(),
+                ownerId,
                 meetup.getSigungu().getId(),
                 meetup.getName(),
                 meetup.getCategory().name(),
@@ -66,6 +69,10 @@ MeetupEntityMapper {
                 .map(MeetupHashTag::getName)
                 .toList();
 
+        ProfileResponse ownerDto = (meetup.getOwner() != null)
+                ? ProfileEntityMapper.toResponseDto(meetup.getOwner())
+                : null;
+
         return new MeetupDetail(
                 meetup.getId(),
                 meetup.getName(),
@@ -74,7 +81,7 @@ MeetupEntityMapper {
                 meetup.getParticipantCount(),
                 meetup.getCapacity(),
                 meetup.getScoreLimit(),
-                ProfileEntityMapper.toResponseDto(meetup.getOwner()),
+                ownerDto,
                 SigunguEntityMapper.toDto(meetup.getSigungu()),
                 location,
                 hashTags,

--- a/src/main/java/com/pnu/momeet/domain/member/service/MemberDomainService.java
+++ b/src/main/java/com/pnu/momeet/domain/member/service/MemberDomainService.java
@@ -1,5 +1,7 @@
 package com.pnu.momeet.domain.member.service;
 
+import com.pnu.momeet.domain.meetup.entity.Meetup;
+import com.pnu.momeet.domain.meetup.service.MeetupEntityService;
 import com.pnu.momeet.domain.member.dto.request.ChangePasswordRequest;
 import com.pnu.momeet.domain.member.dto.request.MemberCreateRequest;
 import com.pnu.momeet.domain.member.dto.request.MemberEditRequest;
@@ -8,6 +10,8 @@ import com.pnu.momeet.domain.member.dto.response.MemberResponse;
 import com.pnu.momeet.domain.member.entity.Member;
 import com.pnu.momeet.domain.member.service.mapper.MemberDtoMapper;
 import com.pnu.momeet.domain.member.service.mapper.MemberEntityMapper;
+import com.pnu.momeet.domain.participant.service.ParticipantDomainService;
+import com.pnu.momeet.domain.profile.service.ProfileEntityService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
@@ -17,6 +21,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 
@@ -27,6 +32,9 @@ public class MemberDomainService {
 
     private final MemberEntityService entityService;
     private final PasswordEncoder passwordEncoder;
+    private final MeetupEntityService meetupEntityService;
+    private final ParticipantDomainService participantService;
+    private final ProfileEntityService profileEntityService;
 
     @Transactional
     public MemberResponse saveMember(MemberCreateRequest request) {
@@ -96,7 +104,20 @@ public class MemberDomainService {
 
     @Transactional
     public void deleteMemberById(UUID id) {
-        entityService.deleteById(id);
+        if (!profileEntityService.existsByMemberId(id)) {
+            entityService.deleteById(id);
+            log.info("사용자 삭제 완료: id={}", id);
+            return;
+        }
+            UUID profileId = profileEntityService.getByMemberId(id).getId();
+            List<Meetup> participatedMeetups = meetupEntityService.getAllParticipatedMeetupsByProfileId(profileId);
+            if (!participatedMeetups.isEmpty()) {
+                participatedMeetups.forEach(meetup -> participantService.leaveMeetupAdmin(meetup.getId(), id));
+                log.info("참여중인 모임에서 탈퇴 처리 완료: memberId={}, profileId={} affectedMeetups={}",
+                        id, profileId, participatedMeetups.size());
+            }
+
+            entityService.deleteById(id);
         log.info("사용자 삭제 완료: id={}", id);
     }
 }

--- a/src/main/java/com/pnu/momeet/domain/participant/entity/Participant.java
+++ b/src/main/java/com/pnu/momeet/domain/participant/entity/Participant.java
@@ -30,6 +30,7 @@ public class Participant extends SimpleCreationEntity {
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "meetup_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Meetup meetup;
 
     @NotNull

--- a/src/main/java/com/pnu/momeet/domain/participant/service/ParticipantDomainService.java
+++ b/src/main/java/com/pnu/momeet/domain/participant/service/ParticipantDomainService.java
@@ -16,7 +16,6 @@ import com.pnu.momeet.domain.profile.entity.Profile;
 import com.pnu.momeet.domain.profile.service.ProfileEntityService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -111,28 +110,50 @@ public class ParticipantDomainService {
 
     @Transactional
     public void leaveMeetup(UUID meetupId, UUID memberId) {
-        Profile profile = profileService.getByMemberId(memberId);
         Meetup meetup = meetupService.getById(meetupId);
-        Participant participant = entityService.getByProfileIDAndMeetupID(profile.getId(), meetupId);
-        
+
         if (meetup.getStatus() != MeetupStatus.OPEN) {
-            log.info("모임에서 나갈 수 없는 상태에서 나감 시도. meetupId={}, profileId={}, status={}",
-                    meetupId, profile.getId(), meetup.getStatus());
+            log.info("모임에서 나갈 수 없는 상태에서 나감 시도. meetupId={}, status={}",
+                    meetupId, meetup.getStatus());
             throw new IllegalArgumentException("모임에서 나갈 수 없는 상태입니다. 현재 상태: "
                     + meetup.getStatus().getDescription());
         }
-        Pair<Participant, Participant> topTwoParticipants;
+        UUID profileId = profileService.mapToProfileId(memberId);
+        Participant participant = entityService.getByProfileIDAndMeetupID(profileId, meetupId);
+        leaveMeetupInternal(meetup, participant);
+    }
+
+    @Transactional
+    public void leaveMeetupAdmin(UUID meetupId, UUID memberId) {
+        Meetup meetup = meetupService.getById(meetupId);
+        UUID profileId = profileService.mapToProfileId(memberId);
+        Participant participant = entityService.getByProfileIDAndMeetupID(profileId, meetupId);
         try {
-             topTwoParticipants = entityService.getTopTwoByTemperatureDesc(meetupId);
-        } catch (NoSuchElementException e) {
+            leaveMeetupInternal(meetup, participant);
+        } catch (IllegalArgumentException e) {
+            meetupService.updateMeetup(meetup, m -> {
+                m.removeParticipant(participant);
+                m.setStatus(MeetupStatus.CANCELED);
+            });
+            meetupService.saveMeetup(meetup);
+            log.info("모임 참가자가 2명 미만으로 호스트가 나감으로 인해 모임 취소 처리. meetupId={}", meetupId);
+        }
+    }
+
+    private void leaveMeetupInternal(Meetup meetup, Participant participant) {
+        UUID meetupId = meetup.getId();
+        UUID profileId = participant.getProfile().getId();
+        var topTwoParticipantsOpt = entityService.getTopTwoByTemperatureDesc(meetupId);
+        if (topTwoParticipantsOpt.isEmpty()) {
             throw new IllegalArgumentException("참가자가 2명 미만인 모임에서는 호스트가 나갈 수 없습니다.");
         }
+        var topTwoParticipants = topTwoParticipantsOpt.get();
+        // 호스트가 나갈 경우 새로운 호스트 지정
         if (participant.getRole() == MeetupRole.HOST) {
-            log.info("호스트가 모임에서 나감 시도. meetupId={}, profileId={}", meetupId, profile.getId());
+            log.info("호스트가 모임에서 나감 시도. meetupId={}, profileId={}", meetupId, profileId);
             Participant replacementHost = topTwoParticipants.getFirst().getId().equals(participant.getId())
                     ? topTwoParticipants.getSecond() // 호스트가 1등일 경우 2등이 호스트 됨
                     : topTwoParticipants.getFirst(); // 아닐 경우 온도가 가장 높은 참가자가 호스트 됨
-
             entityService.updateParticipant(replacementHost, p -> p.setRole(MeetupRole.HOST));
             meetupService.updateMeetup(meetup, m -> m.setOwner(replacementHost.getProfile()));
         }
@@ -140,8 +161,7 @@ public class ParticipantDomainService {
         eventPublisher.publish(new ParticipantExitEvent(meetupId, participant));
         // 참가자 제거 및 참가자 수 감소
         meetupService.updateMeetup(meetup, m -> m.removeParticipant(participant));
-
-        log.info("모임 탈퇴 성공. meetupId={}, profileId={}", meetupId, profile.getId());
+        log.info("모임 탈퇴 성공. meetupId={}, profileId={}", meetupId, profileId);
     }
 
     @Transactional

--- a/src/main/java/com/pnu/momeet/domain/participant/service/ParticipantEntityService.java
+++ b/src/main/java/com/pnu/momeet/domain/participant/service/ParticipantEntityService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
 
@@ -80,15 +81,15 @@ public class ParticipantEntityService {
 
 
     @Transactional
-    public Pair<Participant, Participant> getTopTwoByTemperatureDesc(UUID meetupId) {
+    public Optional<Pair<Participant, Participant>> getTopTwoByTemperatureDesc(UUID meetupId) {
         log.debug("모임 ID로 상위 2명의 참가자 조회 시도. meetupId={}", meetupId);
         var participants = participantRepository.findTopTwoByOrderByTemperatureDesc(meetupId);
         if (participants.size() < 2) {
-            log.info("상위 2명의 참가자가 존재하지 않음. meetupId={}", meetupId);
-            throw new NoSuchElementException("상위 2명의 참가자가 존재하지 않습니다.");
+            log.debug("상위 2명의 참가자가 존재하지 않음. meetupId={}", meetupId);
+            return Optional.empty();
         }
         log.debug("모임 ID로 상위 2명의 참가자 조회 성공. meetupId={}", meetupId);
-        return Pair.of(participants.get(0), participants.get(1));
+        return Optional.of(Pair.of(participants.get(0), participants.get(1)));
     }
 
     @Transactional

--- a/src/main/java/com/pnu/momeet/domain/profile/entity/Profile.java
+++ b/src/main/java/com/pnu/momeet/domain/profile/entity/Profile.java
@@ -18,8 +18,6 @@ import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Table(
@@ -33,7 +31,6 @@ import org.hibernate.annotations.OnDeleteAction;
 public class Profile extends BaseEntity {
 
     @Column(name = "member_id", nullable = false, columnDefinition = "UUID")
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private UUID memberId;
 
     @Column(name = "nickname", length = 20, nullable = false)

--- a/src/main/java/com/pnu/momeet/domain/profile/entity/Profile.java
+++ b/src/main/java/com/pnu/momeet/domain/profile/entity/Profile.java
@@ -18,6 +18,8 @@ import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Table(
@@ -31,6 +33,7 @@ import lombok.NoArgsConstructor;
 public class Profile extends BaseEntity {
 
     @Column(name = "member_id", nullable = false, columnDefinition = "UUID")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private UUID memberId;
 
     @Column(name = "nickname", length = 20, nullable = false)

--- a/src/main/resources/sql/init_scheme.sql
+++ b/src/main/resources/sql/init_scheme.sql
@@ -86,7 +86,7 @@ CREATE INDEX IF NOT EXISTS idx_profile_base_location_id ON profile(base_location
 
 CREATE TABLE meetup (
     id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
-    owner_id        UUID        NOT NULL REFERENCES profile(id),
+    owner_id        UUID        REFERENCES profile(id) ON DELETE SET NULL,
     name            VARCHAR(60) NOT NULL,
     category        VARCHAR(30) NOT NULL,
     description     TEXT        NOT NULL,
@@ -147,7 +147,7 @@ CREATE INDEX IF NOT EXISTS idx_chat_message_sender ON chat_message (sender_id);
 
 CREATE TABLE evaluation (
     id UUID PRIMARY KEY,
-    meetup_id UUID  NOT NULL,
+    meetup_id UUID REFERENCES meetup(id) ON DELETE CASCADE,
     evaluator_profile_id UUID  NOT NULL,
     target_profile_id UUID  NOT NULL,
     rating VARCHAR(10) NOT NULL,

--- a/src/test/resources/sql/test_init_scheme.sql
+++ b/src/test/resources/sql/test_init_scheme.sql
@@ -75,7 +75,7 @@ CREATE INDEX IF NOT EXISTS idx_profile_base_location_id ON public_test.profile(b
 
 CREATE TABLE public_test.meetup (
     id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
-    owner_id        UUID        NOT NULL REFERENCES public_test.profile(id),
+    owner_id        UUID        REFERENCES public_test.profile(id) ON DELETE SET NULL,
     name            VARCHAR(60) NOT NULL,
     category        VARCHAR(30) NOT NULL,
     description     TEXT        NOT NULL,


### PR DESCRIPTION
# Pull Request 템플릿

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 걸어주세요 -->
- Closes #123

## 💡 변경 이유
<!-- 왜 이 코드 변경이 필요했나요? 어떤 문제를 해결하거나 어떤 기능을 추가했나요? -->
모임이 있을 때 member가 회원 탈퇴한다면 profile 삭제로 전파되고 이는 meetup에 유효성을 깨뜨리므로 이 문제를 해결하기 위해 해당 처리를 구현하였습니다. 

## 📋 주요 변경사항
<!-- 구체적으로 어떤 것들이 변경되었는지 간단히 나열해주세요 -->
-  meetup의 ownerId 를 nullabe로 변경하였습니다.
- 만약 특정 모임에 참가하는 중에 회원 탈퇴를 한다면 해당 사용자가 탈퇴하도록 만들었습니다. 
- 만약 2명 이하인 meetup에서 member를 삭제한다면 meetup 상태를 cancel로 변경하도록 만들었습니다.

## ⚠️ 발견된 위험이나 장애
<!-- 개발 중 발견된 문제점이나 주의할 부분이 있다면 작성해주세요 (없으면  삭제) -->
계속해서 "Transaction silently rolled back because it has been marked as rollback-only" 이를 해결했습니다.
 

## ✅ 테스트 완료 사항
<!-- 어떻게 테스트했는지 간단히 작성해주세요 -->
- [X] 로컬에서 정상 동작 확인
- [X] 기존 기능에 영향 없음 확인
- [X] e2e 테스트 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data integrity when deleting user accounts by automatically cleaning up associated meetup participations.
  * Fixed cascade deletion handling for meetup-related data to prevent orphaned records.
  * Enhanced system stability when meetup owners are deleted; their meetups now remain accessible without owner reference.

* **Chores**
  * Updated database schema to support improved data consistency and deletion workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->