### PR TITLE
refactor(profile-evaluation): 내 프로필 삭제 API 추가 및 S3 이미지 정리 비동기 처리, 프로필…

### DIFF
--- a/src/main/java/com/pnu/momeet/domain/evaluation/entity/Evaluation.java
+++ b/src/main/java/com/pnu/momeet/domain/evaluation/entity/Evaluation.java
@@ -25,7 +25,7 @@ public class Evaluation extends BaseCreatedEntity {
     @Column(name = "meetup_id", nullable = false)
     private UUID meetupId;
 
-    @Column(name = "evaluator_profile_id", nullable = false)
+    @Column(name = "evaluator_profile_id")
     private UUID evaluatorProfileId;
 
     @Column(name = "target_profile_id", nullable = false)

--- a/src/main/java/com/pnu/momeet/domain/evaluation/entity/Evaluation.java
+++ b/src/main/java/com/pnu/momeet/domain/evaluation/entity/Evaluation.java
@@ -22,7 +22,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class Evaluation extends BaseCreatedEntity {
 
-    @Column(name = "meetup_id", nullable = false)
+    @Column(name = "meetup_id")
     private UUID meetupId;
 
     @Column(name = "evaluator_profile_id")

--- a/src/main/java/com/pnu/momeet/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/pnu/momeet/domain/profile/controller/ProfileController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -61,5 +62,14 @@ public class ProfileController {
     ) {
         ProfileResponse response = profileService.updateMyProfile(userDetails.getMemberId(), request);
         return ResponseEntity.ok(response);
+    }
+
+    @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> deleteMyProfile(
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        profileService.deleteMyProfile(userDetails.getMemberId());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/pnu/momeet/domain/profile/event/ProfileDeletedEvent.java
+++ b/src/main/java/com/pnu/momeet/domain/profile/event/ProfileDeletedEvent.java
@@ -1,0 +1,27 @@
+package com.pnu.momeet.domain.profile.event;
+
+import com.pnu.momeet.common.event.DomainEvent;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public final class ProfileDeletedEvent extends DomainEvent {
+
+    private final UUID profileId;
+    private final String imageUrl;
+
+    public ProfileDeletedEvent(UUID profileId, String imageUrl) {
+        this.profileId = profileId;
+        this.imageUrl = imageUrl;
+    }
+
+    @Override
+    public Map<String, Object> logInfo() {
+        LinkedHashMap<String, Object> m = new LinkedHashMap<>(super.logInfo());
+        m.put("profileId", profileId);
+        m.put("imageUrl", imageUrl);
+        return m;
+    }
+}

--- a/src/main/java/com/pnu/momeet/domain/profile/service/ProfileDomainService.java
+++ b/src/main/java/com/pnu/momeet/domain/profile/service/ProfileDomainService.java
@@ -1,8 +1,11 @@
 package com.pnu.momeet.domain.profile.service;
 
+import com.pnu.momeet.common.event.CoreEventPublisher;
 import com.pnu.momeet.common.service.S3StorageService;
 import com.pnu.momeet.common.tx.AfterCommitExecutor;
 import com.pnu.momeet.common.util.ImageHashUtil;
+import com.pnu.momeet.domain.evaluation.entity.Evaluation;
+import com.pnu.momeet.domain.evaluation.service.EvaluationDomainService;
 import com.pnu.momeet.domain.profile.command.ProfileChanges;
 import com.pnu.momeet.domain.profile.dto.request.LocationInput;
 import com.pnu.momeet.domain.profile.dto.request.ProfileCreateRequest;
@@ -10,10 +13,12 @@ import com.pnu.momeet.domain.profile.dto.request.ProfileUpdateRequest;
 import com.pnu.momeet.domain.profile.dto.response.ProfileResponse;
 import com.pnu.momeet.domain.profile.entity.Profile;
 import com.pnu.momeet.domain.profile.enums.Gender;
+import com.pnu.momeet.domain.profile.event.ProfileDeletedEvent;
 import com.pnu.momeet.domain.profile.service.mapper.ProfileDtoMapper;
 import com.pnu.momeet.domain.profile.service.mapper.ProfileEntityMapper;
 import com.pnu.momeet.domain.sigungu.entity.Sigungu;
 import com.pnu.momeet.domain.sigungu.service.SigunguEntityService;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,6 +41,8 @@ public class ProfileDomainService {
     private final GeometryFactory geometryFactory;
     private final ImageHashUtil imageHashUtil;
     private final AfterCommitExecutor afterCommitExecutor;
+    private final EvaluationDomainService evaluationDomainService;
+    private final CoreEventPublisher eventPublisher;
 
     @Transactional(readOnly = true)
     public ProfileResponse getMyProfile(UUID memberId) {
@@ -190,5 +197,17 @@ public class ProfileDomainService {
             inSigungu, baseChanged,
             hasImagePart, incomingHash, imageChanged
         );
+    }
+
+    @Transactional
+    public void deleteMyProfile(UUID memberId) {
+        Profile profile = entityService.getByMemberId(memberId);
+        String imageKey = profile.getImageUrl();
+
+        // 2) 프로필 삭제 (라이브 평가들은 FK CASCADE로 자동 삭제)
+        entityService.deleteById(profile.getId());
+
+        // 3) 커밋 후 S3 이미지 정리
+        eventPublisher.publish(new ProfileDeletedEvent(profile.getId(), imageKey));
     }
 }

--- a/src/main/java/com/pnu/momeet/domain/profile/service/listener/ProfileImageCleanupListener.java
+++ b/src/main/java/com/pnu/momeet/domain/profile/service/listener/ProfileImageCleanupListener.java
@@ -1,0 +1,47 @@
+package com.pnu.momeet.domain.profile.service.listener;
+
+import com.pnu.momeet.common.logging.LogTags;
+import com.pnu.momeet.common.service.S3StorageService;
+import com.pnu.momeet.domain.profile.event.ProfileDeletedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProfileImageCleanupListener {
+
+    private final S3StorageService s3StorageService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(ProfileDeletedEvent e) {
+        final String imageUrl = e.getImageUrl();
+        final long started = System.currentTimeMillis();
+
+        log.info("{}, eventId={}, type={}, profileId={}, imageUrl={}",
+            LogTags.HANDLE_START, e.getEventId(), e.type(), e.getProfileId(), imageUrl
+        );
+
+        if (imageUrl == null || imageUrl.isBlank()) {
+            log.info("[ProfileImageCleanup] 삭제할 s3 이미지가 없습니다. (profileId={})", e.getProfileId());
+            return; // 멱등
+        }
+
+        try {
+            s3StorageService.deleteImage(imageUrl);
+            long elapsed = System.currentTimeMillis() - started;
+            log.info("{}, eventId={}, type={}, profileId={}, imageUrl={}, elapsedMs={}",
+                LogTags.HANDLE_END, e.getEventId(), e.type(), e.getProfileId(), imageUrl, elapsed
+            );
+        } catch (Exception ex) {
+            // 멱등/운영안정: 실패해도 서비스 흐름은 방해하지 않음
+            log.info("[ProfileImageCleanup] s3 이미지 삭제에 실패했습니다. (profileId={}, imageUrl={}), cause={}",
+                e.getProfileId(), imageUrl, ex.toString());
+        }
+    }
+}

--- a/src/main/resources/sql/init_scheme.sql
+++ b/src/main/resources/sql/init_scheme.sql
@@ -147,19 +147,22 @@ CREATE INDEX IF NOT EXISTS idx_chat_message_meetup ON chat_message (meetup_id);
 CREATE INDEX IF NOT EXISTS idx_chat_message_sender ON chat_message (sender_id);
 
 CREATE TABLE evaluation (
-    id UUID PRIMARY KEY,
-    meetup_id UUID REFERENCES meetup(id) ON DELETE CASCADE,
-    evaluator_profile_id UUID  NOT NULL,
-    target_profile_id UUID  NOT NULL,
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    meetup_id UUID REFERENCES meetup(id) ON DELETE SET NULL,
+    evaluator_profile_id UUID REFERENCES profile(id) ON DELETE SET NULL,
+    target_profile_id UUID NOT NULL REFERENCES profile(id) ON DELETE CASCADE,
     rating VARCHAR(10) NOT NULL,
     ip_hash VARCHAR(128) NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
 
-    CONSTRAINT uq_evaluation UNIQUE (meetup_id, evaluator_profile_id, target_profile_id, ip_hash),
-    CONSTRAINT fk_evaluation_meetup FOREIGN KEY (meetup_id) REFERENCES meetup(id),
-    CONSTRAINT fk_evaluation_evaluator_profile FOREIGN KEY (evaluator_profile_id) REFERENCES profile(id),
-    CONSTRAINT fk_evaluation_target_profile FOREIGN KEY (target_profile_id) REFERENCES profile(id)
+    CONSTRAINT chk_evaluation_rating CHECK (rating IN ('LIKE','DISLIKE'))
 );
+
+CREATE UNIQUE INDEX uq_evaluation_active
+    ON evaluation(meetup_id, evaluator_profile_id, target_profile_id, ip_hash)
+    WHERE meetup_id IS NOT NULL
+    AND evaluator_profile_id IS NOT NULL
+    AND target_profile_id IS NOT NULL;
 
 
 CREATE TABLE IF NOT EXISTS badge (

--- a/src/test/java/com/pnu/momeet/e2e/evaluation/BaseProfileEvaluationTest.java
+++ b/src/test/java/com/pnu/momeet/e2e/evaluation/BaseProfileEvaluationTest.java
@@ -10,6 +10,11 @@ import com.pnu.momeet.domain.member.service.MemberDomainService;
 import com.pnu.momeet.domain.profile.service.ProfileDomainService;
 import com.pnu.momeet.e2e.BaseE2ETest;
 import io.restassured.RestAssured;
+import io.restassured.builder.MultiPartSpecBuilder;
+import io.restassured.http.ContentType;
+import io.restassured.specification.MultiPartSpecification;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -18,6 +23,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
@@ -26,6 +32,7 @@ public class BaseProfileEvaluationTest extends BaseE2ETest {
     protected Map<Role, TokenResponse> testTokens;
     protected List<UUID> evaluationsToBeDeleted;
     protected UUID test_user_profile_uuid;
+    protected UUID test_admin_profile_uuid;
     protected UUID test_meetup_id;
 
     @Autowired
@@ -55,6 +62,9 @@ public class BaseProfileEvaluationTest extends BaseE2ETest {
         // 테스트용 프로필 ID 설정
         var testMember = memberService.getMemberByEmail(TEST_USER_EMAIL);
         test_user_profile_uuid = profileService.getMyProfile(testMember.id()).id();
+
+        var testAdminMember = memberService.getMemberByEmail(TEST_ADMIN_EMAIL);
+        test_admin_profile_uuid = profileService.getMyProfile(testAdminMember.id()).id();
 
         Page<Meetup> meetups = meetupService.findEndedMeetupsByProfileId(
             test_user_profile_uuid, PageRequest.of(0, 1)

--- a/src/test/java/com/pnu/momeet/e2e/evaluation/ProfileEvaluationGetTest.java
+++ b/src/test/java/com/pnu/momeet/e2e/evaluation/ProfileEvaluationGetTest.java
@@ -1,25 +1,56 @@
 package com.pnu.momeet.e2e.evaluation;
 
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
+import com.pnu.momeet.domain.evaluation.entity.Evaluation;
 import com.pnu.momeet.domain.member.enums.Role;
 import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.annotation.DirtiesContext;
 
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class ProfileEvaluationGetTest extends BaseProfileEvaluationTest {
+
+    private String evaluatorToken; // user
+    private String targetToken;    // admin
+    private UUID evaluatorProfileId;
+    private UUID targetProfileId;
+
+    @BeforeEach
+    void baseSetup() throws IOException {
+        // 평가 생성은 /api/meetups의 상대경로를 쓰므로 basePath는 호출마다 지정
+        evaluatorToken = getToken(Role.ROLE_USER).accessToken();
+        targetToken    = getToken(Role.ROLE_ADMIN).accessToken();
+
+        ensureMyProfile(evaluatorToken);
+        ensureMyProfile(targetToken);
+
+        evaluatorProfileId = fetchMyProfileId(evaluatorToken);
+        targetProfileId    = fetchMyProfileId(targetToken);
+    }
 
     @Test
     @DisplayName("최근 모임 조회 - 미평가만 (evaluated=false) 200 OK")
     void getMeetups_unevaluated_success() {
         String accessToken = getToken(Role.ROLE_USER).accessToken();
 
-        RestAssured
-            .given().log().all()
+        given().log().all()
             .header(AUTH_HEADER, BEAR_PREFIX + accessToken)
             .param("page", 0)
             .param("size", 5)
@@ -38,8 +69,7 @@ public class ProfileEvaluationGetTest extends BaseProfileEvaluationTest {
     void getMeetups_evaluated_success() {
         String accessToken = getToken(Role.ROLE_USER).accessToken();
 
-        RestAssured
-            .given().log().all()
+        given().log().all()
             .header(AUTH_HEADER, BEAR_PREFIX + accessToken)
             .param("page", 0)
             .param("size", 5)
@@ -57,8 +87,7 @@ public class ProfileEvaluationGetTest extends BaseProfileEvaluationTest {
     void getMeetups_mixed_success() {
         String accessToken = getToken(Role.ROLE_USER).accessToken();
 
-        RestAssured
-            .given().log().all()
+        given().log().all()
             .header(AUTH_HEADER, BEAR_PREFIX + accessToken)
             .param("page", 0)
             .param("size", 5)
@@ -74,13 +103,155 @@ public class ProfileEvaluationGetTest extends BaseProfileEvaluationTest {
     @Test
     @DisplayName("최근 모임 조회 - 토큰 없음 401")
     void getMeetups_fail_unauthorized() {
-        RestAssured
-            .given().log().all()
+        given().log().all()
             .param("page", 0)
             .param("size", 5)
             .when()
             .get("/me/meetups")
             .then().log().all()
             .statusCode(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @Test
+    @DisplayName("삭제된 타깃에게는 평가 생성할 수 없다 (200 + invalid)")
+    void cannotCreate_forDeletedTarget_minimal() {
+        UUID meetupId = fetchEndedMeetupId(targetToken);
+        UUID targetId = targetProfileId;
+
+        // 타깃 삭제
+        given().basePath("/api/profiles").header(AUTH_HEADER, BEAR_PREFIX + targetToken)
+            .when().delete("/me")
+            .then().statusCode(204);
+
+        // 삭제된 타깃에게 평가 생성 → 200 + invalid 메시지
+        given().basePath("/api/meetups").header(AUTH_HEADER, BEAR_PREFIX + evaluatorToken)
+            .contentType(ContentType.JSON)
+            .body("""
+            {"items":[{"targetProfileId":"%s","rating":"LIKE"}]}
+            """.formatted(targetId))
+            .when().post("/{meetupId}/evaluations", meetupId)
+            .then().statusCode(200)
+            .body("invalid.size()", is(1))
+            .body("invalid[0].message", containsString("모임 참가자가 아닙니다"));
+    }
+
+    @Test
+    @DisplayName("타깃을 삭제하면 해당 평가는 CASCADE로 제거된다")
+    void cascade_whenTargetDeleted_minimal() {
+        UUID meetupId = fetchEndedMeetupId(targetToken);
+        UUID targetId = targetProfileId;
+
+        // 1) 평가 1건 생성(evaluator → target)
+        ExtractableResponse<Response> res =
+            given().basePath("/api/meetups").header(AUTH_HEADER, BEAR_PREFIX + evaluatorToken)
+                .contentType(ContentType.JSON)
+                .body("""
+                {"items":[{"targetProfileId":"%s","rating":"LIKE"}]}
+                """.formatted(targetId))
+                .when().post("/{meetupId}/evaluations", meetupId)
+                .then().statusCode(200)
+                .extract();
+
+        UUID createdId = UUID.fromString(res.jsonPath().getList("created.id", String.class).getFirst());
+        assertThat(evaluationRepository.findById(createdId)).isPresent();
+
+        // 2) 타깃 삭제 → 평가 CASCADE 제거
+        given().basePath("/api/profiles").header(AUTH_HEADER, BEAR_PREFIX + targetToken)
+            .when().delete("/me")
+            .then().statusCode(204);
+
+        assertThat(evaluationRepository.findById(createdId)).isNotPresent();
+    }
+
+    // helpers
+
+    private UUID ensureMyProfile(String accessToken) {
+        // 1) 먼저 조회
+        var getRes = io.restassured.RestAssured.given().log().all()
+            .basePath("/api/profiles")
+            .header(AUTH_HEADER, BEAR_PREFIX + accessToken)
+            .when().get("/me")
+            .then().log().all()
+            .extract();
+
+        if (getRes.statusCode() == 200) {
+            return java.util.UUID.fromString(getRes.jsonPath().getString("id"));
+        }
+
+        // 2) 없으면 생성 (ProfileCreateTest 스타일로 멀티파트 전송)
+        String nickname = "test_" + java.util.UUID.randomUUID().toString().substring(0, 8);
+
+        // 한글 안정 전송용 UTF-8 멀티파트
+        var nicknamePart = new io.restassured.builder.MultiPartSpecBuilder(nickname)
+            .controlName("nickname")
+            .charset(java.nio.charset.StandardCharsets.UTF_8)
+            .build();
+        var descriptionPart = new io.restassured.builder.MultiPartSpecBuilder("테스트 자기소개입니다.")
+            .controlName("description")
+            .charset(java.nio.charset.StandardCharsets.UTF_8)
+            .build();
+
+        // 테스트 이미지 로드 (classpath: /image/badger.png)
+        byte[] imageBytes = null;
+        try {
+            var resource = new org.springframework.core.io.ClassPathResource("/image/badger.png");
+            imageBytes = resource.getInputStream().readAllBytes();
+        } catch (Exception ignore) {
+            // 이미지가 없어도 생성은 가능하도록 넘어가되, 로컬/CI에서 리소스 확인 권장
+        }
+
+        io.restassured.response.ExtractableResponse<io.restassured.response.Response> createRes =
+            io.restassured.RestAssured.given().log().all()
+                .basePath("/api/profiles")
+                .header(AUTH_HEADER, BEAR_PREFIX + accessToken)
+                .contentType(io.restassured.http.ContentType.MULTIPART)
+                .multiPart(nicknamePart)
+                .multiPart("age", 25)
+                .multiPart("gender", "MALE")
+                .multiPart(descriptionPart)
+                .multiPart("baseLocation.baseLocationId", 26410) // 필드 경로 유지
+                // 이미지가 있으면 첨부 (파일명/콘텐츠타입 ProfileCreateTest와 동일)
+                .multiPart("image", "/image/badger.png", imageBytes, "image/png")
+                .when().post("")
+                .then().log().all()
+                .statusCode(201) // 생성 성공
+                .extract();
+
+        // Location 헤더 및 본문 id 확인(선택 검증)
+        // createRes.header("Location")가 "/api/profiles/" 포함하는지 검사 가능
+        String id = createRes.jsonPath().getString("id");
+        org.assertj.core.api.Assertions.assertThat(id).isNotBlank();
+        return java.util.UUID.fromString(id);
+    }
+
+    // 종료된 모임에서 실제 존재하는 meetupId 1개 가져오기(존재 검증 포함, 간단 버전)
+    private UUID fetchEndedMeetupId(String token) {
+        ExtractableResponse<Response> res =
+            given().basePath("/api/profiles").header(AUTH_HEADER, BEAR_PREFIX + token)
+                .when().get("/me/meetups?page=0&size=5")
+                .then().statusCode(200)
+                .extract();
+
+        List<String> ids = res.jsonPath().getList("content.meetupId");
+        if (ids == null || ids.isEmpty()) {
+            throw new IllegalStateException("테스트용 종료 모임이 필요합니다. (seed 또는 픽스처 확인)");
+        }
+        UUID id = UUID.fromString(ids.getFirst());
+
+        // 존재 확인 한 번(간단)
+        given().basePath("/api/meetups").header(AUTH_HEADER, BEAR_PREFIX + token)
+            .when().get("/{meetupId}", id)
+            .then().statusCode(200);
+
+        return id;
+    }
+
+    private UUID fetchMyProfileId(String token) {
+        String id =
+            given().basePath("/api/profiles").header(AUTH_HEADER, BEAR_PREFIX + token)
+                .when().get("/me")
+                .then().statusCode(200)
+                .extract().jsonPath().getString("id");
+        return UUID.fromString(id);
     }
 }

--- a/src/test/java/com/pnu/momeet/e2e/profile/ProfileDeleteTest.java
+++ b/src/test/java/com/pnu/momeet/e2e/profile/ProfileDeleteTest.java
@@ -1,0 +1,45 @@
+package com.pnu.momeet.e2e.profile;
+
+import static io.restassured.RestAssured.given;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+
+import com.pnu.momeet.common.service.S3StorageService;
+import com.pnu.momeet.domain.member.enums.Role;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+public class ProfileDeleteTest extends BaseProfileTest {
+
+    @MockitoBean
+    S3StorageService s3StorageService; // AFTER_COMMIT 호출만 확인
+
+    @Test
+    @DisplayName("내 프로필 삭제: 204 -> 이후 조회 404, S3 삭제 트리거 호출")
+    void deleteMyProfile_then204_andThen404_andS3CleanupTriggered() {
+        String token = getToken(Role.ROLE_USER).accessToken();
+
+        // delete
+        given()
+            .log().all()
+            .header(AUTH_HEADER, BEAR_PREFIX + token)
+            .when()
+            .delete("/me")
+            .then()
+            .statusCode(204);
+
+        // 재조회 404
+        given()
+            .log().all()
+            .header(AUTH_HEADER, BEAR_PREFIX + token)
+            .when()
+            .get("/me")
+            .then()
+            .statusCode(404);
+
+        // AFTER_COMMIT 비동기 삭제 트리거
+        verify(s3StorageService, atLeastOnce()).deleteImage(anyString());
+    }
+}

--- a/src/test/resources/sql/test_init_scheme.sql
+++ b/src/test/resources/sql/test_init_scheme.sql
@@ -136,19 +136,22 @@ CREATE INDEX IF NOT EXISTS idx_chat_message_meetup ON public_test.chat_message (
 CREATE INDEX IF NOT EXISTS idx_chat_message_sender ON public_test.chat_message (sender_id);
 
 CREATE TABLE public_test.evaluation (
-    id UUID PRIMARY KEY,
-    meetup_id UUID  NOT NULL,
-    evaluator_profile_id UUID  NOT NULL,
-    target_profile_id UUID  NOT NULL,
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    meetup_id UUID REFERENCES public_test.meetup(id) ON DELETE SET NULL,
+    evaluator_profile_id UUID REFERENCES public_test.profile(id) ON DELETE SET NULL,
+    target_profile_id UUID NOT NULL REFERENCES public_test.profile(id) ON DELETE CASCADE,
     rating VARCHAR(10) NOT NULL,
     ip_hash VARCHAR(128) NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
 
-    CONSTRAINT uq_evaluation UNIQUE (meetup_id, evaluator_profile_id, target_profile_id, ip_hash),
-    CONSTRAINT fk_evaluation_meetup FOREIGN KEY (meetup_id) REFERENCES public_test.meetup(id),
-    CONSTRAINT fk_evaluation_evaluator_profile FOREIGN KEY (evaluator_profile_id) REFERENCES public_test.profile(id),
-    CONSTRAINT fk_evaluation_target_profile FOREIGN KEY (target_profile_id) REFERENCES public_test.profile(id)
+    CONSTRAINT chk_evaluation_rating CHECK (rating IN ('LIKE','DISLIKE'))
 );
+
+CREATE UNIQUE INDEX uq_evaluation_active
+    ON public_test.evaluation(meetup_id, evaluator_profile_id, target_profile_id, ip_hash)
+    WHERE meetup_id IS NOT NULL
+    AND evaluator_profile_id IS NOT NULL
+    AND target_profile_id IS NOT NULL;
 
 CREATE TABLE public_test.badge (
     id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),


### PR DESCRIPTION
# Pull Request 템플릿

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 걸어주세요 -->
- Closes #(127)

## 💡 변경 이유
<!-- 왜 이 코드 변경이 필요했나요? 어떤 문제를 해결하거나 어떤 기능을 추가했나요? -->

회원 탈퇴 시 프로필 하드 삭제 요구사항 반영 및 삭제 후 S3 이미지 정리를 트랜잭션 커밋 뒤 비동기로 처리해 운영 흐름 안전성 확보.
평가(Evaluation) 보존 정책 정리: 모임/평가 강결합을 약화하여 모임 삭제 시에도 평가 이력을 유지(문맥만 끊기)하고, 프로필 삭제 시 일관된 동작을 보장.

## 📋 주요 변경사항
<!-- 구체적으로 어떤 것들이 변경되었는지 간단히 나열해주세요 -->
- API
  - `DELETE /api/profiles/me` 추가
- 도메인 이벤트 & 리스너
  - ProfileDeletedEvent 도입(삭제된 프로필 id, imageUrl 제공)
  - ProfileImageCleanupListener에서 @TransactionalEventListener(AFTER_COMMIT) + @Async로 S3 이미지 삭제(멱등/실패시 로그만)
- 서비스
  - deleteMyProfile(memberId)에서 엔티티 하드 삭제 후 이벤트 발행
- 스키마(evaluation)
  - meetup_id → ON DELETE SET NULL (모임 삭제 시 평가 보존)
  - evaluator_profile_id → ON DELETE SET NULL (평가자 삭제 시 흔적 보존).
  - target_profile_id → NOT NULL + ON DELETE CASCADE (타깃 삭제 시 해당 평가 삭제).
  - rating 값 제약: CHECK (LIKE | DISLIKE)
  - “활성 평가” 중복 방지 부분 유니크 인덱스: (meetup_id, evaluator_profile_id, target_profile_id, ip_hash) WHERE 모두 NOT NULL.
  - 테스트 스키마(public_test) 동일하게 적용.

## ⚠️ 발견된 위험이나 장애
<!-- 개발 중 발견된 문제점이나 주의할 부분이 있다면 작성해주세요 (없으면  삭제) -->


## 👀 리뷰 포인트
<!-- 리뷰어가 특별히 집중해서 봐야 할 부분을 알려주세요 -->
- 프로필 삭제 → 이벤트 발행 → 커밋 후 S3 정리 흐름이 비즈니스 경계에 맞게 설계되었는지
- 평가 스키마 변경이 중복/쿨타임 검증 쿼리에 영향 없는지(meetup_id IS NOT NULL 전제/INNER JOIN 경로)

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 (없으면 삭제해도 됩니다) -->


## ✅ 테스트 완료 사항
<!-- 어떻게 테스트했는지 간단히 작성해주세요 -->
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
- [x] (기타 테스트 내용)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added profile deletion capability for authenticated users.
  * Automatic cleanup of associated image assets when profiles are removed.

* **Bug Fixes**
  * Improved data integrity with proper cascade deletion rules for related records.
  * Enhanced validation constraints to prevent invalid data states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->