### PR TITLE
feat(validation): 프론트엔드 효율성을 위해 초단위 입력도 허용

### DIFF
--- a/src/main/java/com/pnu/momeet/common/validation/annotation/MeetupTimeUnit.java
+++ b/src/main/java/com/pnu/momeet/common/validation/annotation/MeetupTimeUnit.java
@@ -11,7 +11,7 @@ import java.lang.annotation.*;
 @Target({ElementType.FIELD, ElementType.PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface MeetupTimeUnit {
-    String message() default "'yyyy-MM-ddTHH:mm' 형식의 10분 단위 시간만 허용됩니다.";
+    String message() default "'yyyy-MM-ddTHH:mm(:ss)' 형식의 10분 단위 시간만 허용됩니다.";
     Class<?>[] groups() default {};
     Class<? extends Payload>[] payload() default {};
 }

--- a/src/main/java/com/pnu/momeet/common/validation/validator/MeetupTimeUnitValidator.java
+++ b/src/main/java/com/pnu/momeet/common/validation/validator/MeetupTimeUnitValidator.java
@@ -6,10 +6,16 @@ import jakarta.validation.ConstraintValidatorContext;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 
 public class MeetupTimeUnitValidator implements ConstraintValidator<MeetupTimeUnit, String> {
-    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm");
+    private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd'T'HH:mm")
+            .optionalStart()
+            .appendPattern(":ss")
+            .optionalEnd()
+            .toFormatter();
 
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
@@ -19,7 +25,8 @@ public class MeetupTimeUnitValidator implements ConstraintValidator<MeetupTimeUn
         try {
             LocalDateTime dt = LocalDateTime.parse(value, FORMATTER);
             int minute = dt.getMinute();
-            return minute % 10 == 0; // 10분 단위가 아니면 false 반환
+            int second = dt.getSecond();
+            return second == 0 && minute % 10 == 0; // 10분 단위인지 확인
         } catch (DateTimeParseException e) {
             return false;
         }


### PR DESCRIPTION
# Pull Request 템플릿

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 걸어주세요 -->
- Closes #130 

## 💡 변경 이유
<!-- 왜 이 코드 변경이 필요했나요? 어떤 문제를 해결하거나 어떤 기능을 추가했나요? -->
프론트 엔드 요청

## 📋 주요 변경사항
<!-- 구체적으로 어떤 것들이 변경되었는지 간단히 나열해주세요 -->
- 초 단위에 입력도 유연하게 적용 가능하도록 수정

## ✅ 테스트 완료 사항
<!-- 어떻게 테스트했는지 간단히 작성해주세요 -->
- [X] 로컬에서 정상 동작 확인
- [X] 기존 기능에 영향 없음 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes & Improvements

* **Improved Meetup Time Validation** – Updated error messaging to clarify that seconds are optional when entering meetup times. The system now accepts times in both "yyyy-MM-ddTHH:mm" and "yyyy-MM-ddTHH:mm(:ss)" formats while maintaining the 10-minute interval requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->